### PR TITLE
Move test dependencies from Tox config to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,4 +43,7 @@ setup(
     install_requires=[
         "requests"
     ],
+    extras_require={
+        'test': ['tox', 'pytest']
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,6 @@ setup(
         "requests"
     ],
     extras_require={
-        'test': ['tox', 'pytest']
+        'test': ['tox', 'pytest', 'flake8']
     }
 )

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ commands=/bin/bash -c "py.test test"
 
 [testenv:pep8]
 skip_install = True
-deps = flake8
 commands = /bin/bash -c "flake8 matrix_client samples {env:PEP8SUFFIX:}"
 
 [testenv:packaging]

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist =  py27,py34,py35,packaging,pep8
+envlist = py27,py34,py35,packaging,pep8
 
 [testenv]
 setenv =
     PYTHONDONTWRITEBYTECODE = no_byte_code
-deps = pytest
+deps = .[test]
 commands=/bin/bash -c "py.test test"
 
 


### PR DESCRIPTION
This allows for the installation of test dependencies with `pip install .[test]`, which is useful for contributors wanting to installed the required development/testing dependencies. It also keeps all of the dependencies in one central location which is surely a nice thing to have.