### PR TITLE
Implemented /sync and deprecated /initialSync

### DIFF
--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -76,25 +76,35 @@ class MatrixHttpApi(object):
         """
         return self._send("GET", "/initialSync", query_params={"limit": limit})
 
-    def sync(self, since="", timeout_ms=30000, **kwargs):
+    def sync(self, since=None, timeout_ms=30000, filter=None,
+             full_state=None, set_presence=None):
         """ Perform a sync request.
 
         Args:
-            since(string): Optional. A token which specifies where to continue
+            since(str): Optional. A token which specifies where to continue
                 a sync from.
             timeout_ms(int): Optional. The time in milliseconds to wait.
-            **kwargs: Specify filter, full_state or set_presence here.
+            filter (int|str): Either a Filter ID or a JSON string.
+            full_state (bool): Return the full state for every room the user has joined
+                Defaults to false.
+            set_presence (str): Should the client be marked as "online" or" offline"
         """
+
         request = {
             "timeout": timeout_ms
         }
 
-        if since != "":
+        if since:
             request["since"] = since
 
-        for i in ["filter", "fullstate", "set_presence"]:
-            if i in kwargs:
-                request[i] = kwargs[i]
+        if filter:
+            request["filter"] = filter
+
+        if full_state:
+            request["full_state"] = full_state
+
+        if set_presence:
+            request["set_presence"] = set_presence
 
         return self._send("GET", "/sync", query_params=request,
                           api_path="/_matrix/client/r0")

--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -77,7 +77,7 @@ class MatrixHttpApi(object):
         return self._send("GET", "/initialSync", query_params={"limit": limit})
 
     def sync(self, since="", timeout_ms=30000, **kwargs):
-        """ Preform a sync request.
+        """ Perform a sync request.
 
         Args:
             since(string): Optional. A token which specifies where to continue

--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -76,7 +76,7 @@ class MatrixHttpApi(object):
         """
         return self._send("GET", "/initialSync", query_params={"limit": limit})
 
-    def sync(self, since="", timeout_ms=30000,  **kwargs):
+    def sync(self, since="", timeout_ms=30000, **kwargs):
         """ Preform a sync request.
 
         Args:

--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -49,7 +49,7 @@ class MatrixHttpApi(object):
 
     Usage:
         matrix = MatrixHttpApi("https://matrix.org", token="foobar")
-        response = matrix.initial_sync()
+        response = matrix.sync()
         response = matrix.send_message("!roomid:matrix.org", "Hello!")
 
     For room and sync handling, consider using MatrixClient.
@@ -68,12 +68,36 @@ class MatrixHttpApi(object):
         self.validate_cert = True
 
     def initial_sync(self, limit=1):
-        """Perform /initialSync.
+        """ Deprecated. Use sync instead.
+        Perform /initialSync.
 
         Args:
             limit(int): The limit= param to provide.
         """
         return self._send("GET", "/initialSync", query_params={"limit": limit})
+
+    def sync(self, since="", timeout_ms=30000,  **kwargs):
+        """ Preform a sync request.
+
+        Args:
+            since(string): Optional. A token which specifies where to continue
+                a sync from.
+            timeout_ms(int): Optional. The time in milliseconds to wait.
+            **kwargs: Specify filter, full_state or set_presence here.
+        """
+        request = {
+            "timeout": timeout_ms
+        }
+
+        if since != "":
+            request["since"] = since
+
+        for i in ["filter", "fullstate", "set_presence"]:
+            if i in kwargs:
+                request[i] = kwargs[i]
+
+        return self._send("GET", "/sync", query_params=request,
+                          api_path="/_matrix/client/r0")
 
     def validate_certificate(self, valid):
         self.validate_cert = valid
@@ -140,7 +164,8 @@ class MatrixHttpApi(object):
         return self._send("POST", path)
 
     def event_stream(self, from_token, timeout=30000):
-        """Performs /events
+        """ Deprecated. Use sync instead.
+        Performs /events
 
         Args:
             from_token(str): The 'from' query parameter.

--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -81,10 +81,10 @@ class MatrixClient(object):
         if token:
             self._sync()
 
-    def get_sync_token():
+    def get_sync_token(self):
         return self.sync_token
 
-    def set_sync_token(token):
+    def set_sync_token(self, token):
         self.sync_token = token
 
     def register_with_password(self, username, password, limit=1):
@@ -196,7 +196,7 @@ class MatrixClient(object):
             timeout_ms (int): How long to poll the Home Server for before
                retrying.
         """
-        _sync(timeout_ms)
+        self._sync(timeout_ms)
 
     def listen_forever(self, timeout_ms=30000):
         """ Keep listening for events forever.

--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -109,7 +109,7 @@ class MatrixClient(object):
         self.hs = response["home_server"]
         self.api.token = self.token
         self._sync()
-        return self.token  # JIM S: MEDIOGRE
+        return self.token
 
     def login_with_password(self, username, password, limit=1):
         """ Login to the homeserver.

--- a/samples/SimpleChatClient.py
+++ b/samples/SimpleChatClient.py
@@ -13,6 +13,7 @@
 
 import sys
 import samples_common  # Common bits used between samples
+import logging
 
 from matrix_client.client import MatrixClient
 from matrix_client.api import MatrixRequestError
@@ -71,7 +72,7 @@ def main(host, username, password, room_id_alias):
             room.send_text(msg)
 
 if __name__ == '__main__':
-
+    logging.basicConfig(level=logging.WARNING)
     host, username, password = samples_common.get_user_details(sys.argv)
 
     if len(sys.argv) > 4:


### PR DESCRIPTION
This fixes #17 and #30 

I've removed some of the v1 API of ye olden days and replaced it with the new API, there shouldn't be any breaking changes for *client* users.

Also, this should be more sensible when dealing with interruptions (by either backing off or throwing depending on if we can recover) which should help users getting issues running their bots longterm.