### PR TITLE
client: Pass room as arguement to event callbacks.

### DIFF
--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -393,7 +393,7 @@ class Room(object):
             self.events.pop(0)
 
         for listener in self.listeners:
-            listener(event)
+            listener(self, event)
 
     def get_events(self):
         """ Get the most recent events for this room.


### PR DESCRIPTION
When we get an event, the room part is striped away before the event
callback on the room gets the event. So inside the callback there
is no easy way to find in which room the event has happened.

Signed-off-by: Daniel Ehlers <sargon@toppoint.de>