### PR TITLE
chore(requirements): Add ones for docs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         'requests'
     ],
     extras_require={
-        'test': ['tox', 'pytest', 'flake8']
+        'test': ['tox', 'pytest', 'flake8'],
+        'doc': ['Sphinx==1.4.6', 'sphinx-rtd-theme==0.1.9', 'sphinxcontrib-napoleon==0.5.3'],
     }
 )


### PR DESCRIPTION
This explicitly lists dependencies for documents generation in a top-level requirements file, which seems like a good idea in general and is especially useful if one uses virtualenvs like I do. Also, hope it'll save someone from the rather cryptic errors one can get having `python-sphinx` installed with OS package manager, but not having `Sphinx` installed with pip.

Signed-off-by: Dmitriy Volkov <wldhx@wldhx.me>