### PR TITLE
Change default sync limit from 1 to 10.

### DIFF
--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -123,7 +123,7 @@ class MatrixClient(object):
         self._sync()
         return self.token
 
-    def login_with_password(self, username, password, limit=1):
+    def login_with_password(self, username, password, limit=10):
         """ Login to the homeserver.
 
         Args:
@@ -148,7 +148,6 @@ class MatrixClient(object):
 
         """ Limit Filter """
         self.sync_filter = '{ "room": { "timeline" : { "limit" : %i } } }' % limit
-
         self._sync()
         return self.token
 


### PR DESCRIPTION
Not sure why a limit of 1 was set for syncing, as that seems rather low. The proposed new default is 10.