### PR TITLE
Add timestamp to txn_id

### DIFF
--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -216,7 +216,7 @@ class MatrixHttpApi(object):
             txn_id(int): Optional. The transaction ID to use.
         """
         if not txn_id:
-            txn_id = self.txn_id + int(time() * 1000)
+            txn_id = str(self.txn_id) + str(int(time() * 1000))
 
         self.txn_id = self.txn_id + 1
 

--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -16,6 +16,7 @@
 import json
 import re
 import requests
+from time import time
 
 try:
     from urllib import quote
@@ -215,7 +216,7 @@ class MatrixHttpApi(object):
             txn_id(int): Optional. The transaction ID to use.
         """
         if not txn_id:
-            txn_id = self.txn_id
+            txn_id = self.txn_id + int(time() * 1000)
 
         self.txn_id = self.txn_id + 1
 


### PR DESCRIPTION
This fixes #48 partially. A queuing system still needs to be designed, but this should help the poor souls who are sending messages and getting them rejected due to similar txn_ids.