### PR TITLE
Add api tests for tags and account_data 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'requests'
     ],
     extras_require={
-        'test': ['tox', 'pytest', 'flake8'],
+        'test': ['tox', 'pytest', 'flake8', 'responses'],
         'doc': ['Sphinx==1.4.6', 'sphinx-rtd-theme==0.1.9', 'sphinxcontrib-napoleon==0.5.3'],
     }
 )

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -1,0 +1,39 @@
+import responses
+from matrix_client import client
+
+
+class TestTagsApi:
+    cli = client.MatrixClient("https://example.com")
+    user_id = "@user:matrix.org"
+    room_id = "#foo:matrix.org"
+
+    @responses.activate
+    def test_get_user_tags(self):
+
+        tags_url = "https://example.com" \
+            "/_matrix/client/r0/user/@user:matrix.org/rooms/#foo:matrix.org/tags"
+        responses.add(responses.GET, tags_url, body='{}')
+        self.cli.api.get_user_tags(self.user_id, self.room_id)
+        req = responses.calls[0].request
+        assert req.url == tags_url
+        assert req.method == 'GET'
+
+    @responses.activate
+    def test_add_user_tags(self):
+        tags_url = "https://example.com" \
+            "/_matrix/client/r0/user/@user:matrix.org/rooms/#foo:matrix.org/tags/foo"
+        responses.add(responses.PUT, tags_url, body='{}')
+        self.cli.api.add_user_tag(self.user_id, self.room_id, "foo", body={"order": "5"})
+        req = responses.calls[0].request
+        assert req.url == tags_url
+        assert req.method == 'PUT'
+
+    @responses.activate
+    def test_remove_user_tags(self):
+        tags_url = "https://example.com" \
+            "/_matrix/client/r0/user/@user:matrix.org/rooms/#foo:matrix.org/tags/foo"
+        responses.add(responses.DELETE, tags_url, body='{}')
+        self.cli.api.remove_user_tag(self.user_id, self.room_id, "foo")
+        req = responses.calls[0].request
+        assert req.url == tags_url
+        assert req.method == 'DELETE'

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -3,14 +3,13 @@ from matrix_client import client
 
 
 class TestTagsApi:
-    cli = client.MatrixClient("https://example.com")
+    cli = client.MatrixClient("http://example.com")
     user_id = "@user:matrix.org"
     room_id = "#foo:matrix.org"
 
     @responses.activate
     def test_get_user_tags(self):
-
-        tags_url = "https://example.com" \
+        tags_url = "http://example.com" \
             "/_matrix/client/r0/user/@user:matrix.org/rooms/#foo:matrix.org/tags"
         responses.add(responses.GET, tags_url, body='{}')
         self.cli.api.get_user_tags(self.user_id, self.room_id)
@@ -20,7 +19,7 @@ class TestTagsApi:
 
     @responses.activate
     def test_add_user_tags(self):
-        tags_url = "https://example.com" \
+        tags_url = "http://example.com" \
             "/_matrix/client/r0/user/@user:matrix.org/rooms/#foo:matrix.org/tags/foo"
         responses.add(responses.PUT, tags_url, body='{}')
         self.cli.api.add_user_tag(self.user_id, self.room_id, "foo", body={"order": "5"})
@@ -30,10 +29,36 @@ class TestTagsApi:
 
     @responses.activate
     def test_remove_user_tags(self):
-        tags_url = "https://example.com" \
+        tags_url = "http://example.com" \
             "/_matrix/client/r0/user/@user:matrix.org/rooms/#foo:matrix.org/tags/foo"
         responses.add(responses.DELETE, tags_url, body='{}')
         self.cli.api.remove_user_tag(self.user_id, self.room_id, "foo")
         req = responses.calls[0].request
         assert req.url == tags_url
         assert req.method == 'DELETE'
+
+
+class TestAccountDataApi:
+    cli = client.MatrixClient("http://example.com")
+    user_id = "@user:matrix.org"
+    room_id = "#foo:matrix.org"
+
+    @responses.activate
+    def test_set_account_data(self):
+        account_data_url = "http://example.com" \
+            "/_matrix/client/r0/user/@user:matrix.org/account_data/foo"
+        responses.add(responses.PUT, account_data_url, body='{}')
+        self.cli.api.set_account_data(self.user_id, 'foo', {'bar': 1})
+        req = responses.calls[0].request
+        assert req.url == account_data_url
+        assert req.method == 'PUT'
+
+    @responses.activate
+    def test_set_room_account_data(self):
+        account_data_url = "http://example.com/_matrix/client/r0/user" \
+            "/@user:matrix.org/rooms/#foo:matrix.org/account_data/foo"
+        responses.add(responses.PUT, account_data_url, body='{}')
+        self.cli.api.set_room_account_data(self.user_id, self.room_id, 'foo', {'bar': 1})
+        req = responses.calls[0].request
+        assert req.url == account_data_url
+        assert req.method == 'PUT'


### PR DESCRIPTION
@Half-Shot I added `responses` as a dep but if you have a preferred library / configuration for mocking requests in tests I will be happy to switch to that. 
