### PR TITLE
Add 'room_id' attribute to events

### DIFF
--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -353,9 +353,11 @@ class MatrixClient(object):
             room = self.rooms[room_id]
 
             for event in sync_room["state"]["events"]:
+                event['room_id'] = room_id
                 self._process_state_event(event, room)
 
             for event in sync_room["timeline"]["events"]:
+                event['room_id'] = room_id
                 room._put_event(event)
 
                 # Dispatch for client (global) listeners


### PR DESCRIPTION
Currently, client listeners have no way to determine the room from which the event is coming from. This simple pull request aims to fix that, by adding attribute `room_id` to event metadata.
