### PR TITLE
matrix_client/client.py: Fix get_rooms documentation

### DIFF
--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -193,10 +193,10 @@ class MatrixClient(object):
         return self._mkroom(room_id)
 
     def get_rooms(self):
-        """ Return a list of Room objects that the user has joined.
+        """ Return a dict of {room_id: Room objects} that the user has joined.
 
         Returns:
-            Room[]: Rooms the user has joined.
+            Room{}: Rooms the user has joined.
 
         """
         return self.rooms


### PR DESCRIPTION
Function returns a dict not a list, we don't want to confuse anyone.

Issue: #73
Signed-off-by: Gal Pressman <galpressman@gmail.com>