### PR TITLE
matrix_client: Add send location requests

### DIFF
--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -221,6 +221,29 @@ class MatrixHttpApi(object):
         }
         return self.send_message_event(room_id, "m.room.message", content_pack)
 
+    # http://matrix.org/docs/spec/client_server/r0.2.0.html#m-location
+    def send_location(self, room_id, geo_uri, name, thumb_url=None, thumb_info=None):
+        """Send m.location message event
+
+        Args:
+            room_id(str): The room ID to send the event in.
+            geo_uri(str): The geo uri representing the location.
+            name(str): Description for the location.
+            thumb_url(str): URL to the thumbnail of the location.
+            thumb_info(dict): Metadata about the thumbnail, type ImageInfo.
+        """
+        content_pack = {
+            "geo_uri": geo_uri,
+            "msgtype": "m.location",
+            "body": name,
+        }
+        if thumb_url:
+            content_pack["thumbnail_url"] = thumb_url
+        if thumb_info:
+            content_pack["thumbnail_info"] = thumb_info
+
+        return self.send_message_event(room_id, "m.room.message", content_pack)
+
     def send_message(self, room_id, text_content, msgtype="m.text"):
         """Perform /rooms/$room_id/send/m.room.message
 

--- a/matrix_client/room.py
+++ b/matrix_client/room.py
@@ -98,7 +98,7 @@ class Room(object):
         """
         return self.client.api.send_location(self.room_id, geo_uri, name,
                                              thumb_url, thumb_info)
-      
+
     # See http://matrix.org/docs/spec/client_server/r0.2.0.html#m-video for the
     # videoinfo args.
     def send_video(self, url, name, **videoinfo):

--- a/matrix_client/room.py
+++ b/matrix_client/room.py
@@ -82,6 +82,20 @@ class Room(object):
             extra_information=imageinfo
         )
 
+    def send_location(self, geo_uri, name, thumb_url=None, **thumb_info):
+        """ Send a location to the room.
+        See http://matrix.org/docs/spec/client_server/r0.2.0.html#m-location
+        for thumb_info
+
+        Args:
+            geo_uri (str): The geo uri representing the location.
+            name (str): Description for the location.
+            thumb_url (str): URL to the thumbnail of the location.
+            thumb_info (): Metadata about the thumbnail, type ImageInfo.
+        """
+        return self.client.api.send_location(self.room_id, geo_uri, name,
+                                             thumb_url, thumb_info)
+
     def add_listener(self, callback, event_type=None):
         """ Add a callback handler for events going to this room.
 


### PR DESCRIPTION
Introduce send_location() to api and client.
Implemented according to:
http://matrix.org/docs/spec/client_server/r0.2.0.html#m-image

Signed-off-by: Gal Pressman <galpressman@gmail.com>