### PR TITLE
matrix_client/client.py: Remove room from rooms dict on leave event

### DIFF
--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -346,6 +346,8 @@ class MatrixClient(object):
         for room_id, left_room in response['rooms']['leave'].items():
             for listener in self.left_listeners:
                 listener(room_id, left_room)
+            if room_id in self.rooms:
+                del self.rooms[room_id]
 
         for room_id, sync_room in response['rooms']['join'].items():
             if room_id not in self.rooms:


### PR DESCRIPTION
I guess this doesn't include _everything_ we should do on `leave` events, but at least it makes join and leave flows more symmetric and have a more updated rooms status.

```
When receiving a leave event, we should remove the room from our rooms
dictionary since it is no longer meaningful for us.
This fix also makes join and leave events more symmetric.

Signed-off-by: Gal Pressman <galpressman@gmail.com>
```