### PR TITLE
matrix_client: Allow dynamic removal of listeners

### DIFF
--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -18,6 +18,7 @@ from .room import Room
 from .user import User
 from threading import Thread
 from time import sleep
+from uuid import uuid4
 import logging
 import sys
 
@@ -209,13 +210,28 @@ class MatrixClient(object):
         Args:
             callback (func(roomchunk)): Callback called when an event arrives.
             event_type (str): The event_type to filter for.
+
+        Returns:
+            uuid.UUID: Unique id of the listener, can be used to identify the listener.
         """
+        listener_uid = uuid4()
         self.listeners.append(
             {
+                'uid': listener_uid,
                 'callback': callback,
                 'event_type': event_type
             }
         )
+        return listener_uid
+
+    def remove_listener(self, uid):
+        """ Remove listener with given uid.
+
+        Args:
+            uuid.UUID: Unique id of the listener to remove.
+        """
+        self.listeners[:] = (listener for listener in self.listeners
+                             if listener['uid'] != uid)
 
     def add_ephemeral_listener(self, callback, event_type=None):
         """ Add an ephemeral listener that will send a callback when the client recieves
@@ -224,13 +240,28 @@ class MatrixClient(object):
         Args:
             callback (func(roomchunk)): Callback called when an ephemeral event arrives.
             event_type (str): The event_type to filter for.
+
+        Returns:
+            uuid.UUID: Unique id of the listener, can be used to identify the listener.
         """
+        listener_id = uuid4()
         self.ephemeral_listeners.append(
             {
+                'uid': listener_id,
                 'callback': callback,
                 'event_type': event_type
             }
         )
+        return listener_id
+
+    def remove_ephemeral_listener(self, uid):
+        """ Remove ephemeral listener with given uid.
+
+        Args:
+            uuid.UUID: Unique id of the listener to remove.
+        """
+        self.ephemeral_listeners[:] = (listener for listener in self.ephemeral_listeners
+                                       if listener['uid'] != uid)
 
     def add_invite_listener(self, callback):
         """ Add a listener that will send a callback when the client receives

--- a/matrix_client/room.py
+++ b/matrix_client/room.py
@@ -1,4 +1,5 @@
 from .errors import MatrixRequestError
+from uuid import uuid4
 
 
 class Room(object):
@@ -89,13 +90,27 @@ class Room(object):
         Args:
             callback (func(roomchunk)): Callback called when an event arrives.
             event_type (str): The event_type to filter for.
+        Returns:
+            uuid.UUID: Unique id of the listener, can be used to identify the listener.
         """
+        listener_id = uuid4()
         self.listeners.append(
             {
+                'uid': listener_id,
                 'callback': callback,
                 'event_type': event_type
             }
         )
+        return listener_id
+
+    def remove_listener(self, uid):
+        """ Remove listener with given uid.
+
+        Args:
+            uuid.UUID: Unique id of the listener to remove.
+        """
+        self.listeners[:] = (listener for listener in self.listeners
+                             if listener['uid'] != uid)
 
     def add_ephemeral_listener(self, callback, event_type=None):
         """ Add a callback handler for ephemeral events going to this room.
@@ -103,13 +118,27 @@ class Room(object):
         Args:
             callback (func(roomchunk)): Callback called when an ephemeral event arrives.
             event_type (str): The event_type to filter for.
+        Returns:
+            uuid.UUID: Unique id of the listener, can be used to identify the listener.
         """
+        listener_id = uuid4()
         self.ephemeral_listeners.append(
             {
+                'uid': listener_id,
                 'callback': callback,
                 'event_type': event_type
             }
         )
+        return listener_id
+
+    def remove_ephemeral_listener(self, uid):
+        """ Remove ephemeral listener with given uid.
+
+        Args:
+            uuid.UUID: Unique id of the listener to remove.
+        """
+        self.ephemeral_listeners[:] = (listener for listener in self.ephemeral_listeners
+                                       if listener['uid'] != uid)
 
     def add_state_listener(self, callback, event_type=None):
         """ Add a callback handler for state events going to this room.


### PR DESCRIPTION
Adding listeners is an action that cannot be reversed, while many users
need the ability to dynamically change whether they want to listen or not.
This patch assigns each listener with a unique id which allows users to
use it as a later reference for the same listener in case they want to
remove it.
This infrastructure can also be used in future commits to allow modifying
of listeners on-the-go.

Signed-off-by: Gal Pressman <galpressman@gmail.com>