### PR TITLE
matrix_client: Get room's messages history

### DIFF
--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -263,6 +263,29 @@ class MatrixHttpApi(object):
         }
         return self.send_message_event(room_id, "m.room.message", body)
 
+    def get_room_messages(self, room_id, token, direction, limit=10, to=None):
+        """Perform GET /rooms/{roomId}/messages.
+
+        Args:
+            room_id (str): The room's id.
+            token (str): The token to start returning events from.
+            direction (str):  The direction to return events from. One of: ["b", "f"].
+            limit (int): The maximum number of events to return.
+            to (str): The token to stop returning events at.
+        """
+        query = {
+            "roomId": room_id,
+            "from": token,
+            "dir": direction,
+            "limit": limit,
+        }
+
+        if to:
+            query["to"] = to
+
+        return self._send("GET", "/rooms/{}/messages".format(quote(room_id)),
+                          query_params=query, api_path="/_matrix/client/r0")
+
     def get_room_name(self, room_id):
         """Perform GET /rooms/$room_id/state/m.room.name
         Args:

--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -418,6 +418,7 @@ class MatrixClient(object):
             if room_id not in self.rooms:
                 self._mkroom(room_id)
             room = self.rooms[room_id]
+            room.prev_batch = sync_room["timeline"]["prev_batch"]
 
             for event in sync_room["state"]["events"]:
                 event['room_id'] = room_id

--- a/matrix_client/room.py
+++ b/matrix_client/room.py
@@ -29,6 +29,7 @@ class Room(object):
         self.name = None
         self.aliases = []
         self.topic = None
+        self._prev_batch = None
 
     def send_text(self, text):
         """ Send a plain text message to the room.
@@ -374,3 +375,22 @@ class Room(object):
             return True
         except MatrixRequestError:
             return False
+
+    def backfill_previous_messages(self, limit=10):
+        """Backfill handling of previous messages.
+
+        Args:
+            limit (int): Number of messages to go back.
+        """
+        res = self.client.api.get_room_messages(self.room_id, self.prev_batch,
+                                                direction="b", limit=limit)
+        for event in res["chunk"]:
+            self._put_event(event)
+
+    @property
+    def prev_batch(self):
+        return self._prev_batch
+
+    @prev_batch.setter
+    def prev_batch(self, prev_batch):
+        self._prev_batch = prev_batch


### PR DESCRIPTION
This patch introduces the following changes to the matrix_client:
1. Implement rooms/{roomId}/messages endpoint in api.py.
2. Store a 'prev_batch' for each room object, updated through _sync() method.
3. Allow processing of N last events of a specific room (room.py).

Motivation:
In some cases my client does not want to focus and handle events from
all different rooms he is listening to, although he might want to in
the future. So in case my listener chooses to ignore the event for now,
I need a way to access the events history in order to handle them properly.

repeat_last_messages() will allow clients to "relive" their history, including
notifying their respected listeners.

Signed-off-by: Gal Pressman <galpressman@gmail.com>