### PR TITLE
room.py: Fix room's add listeners docstring

### DIFF
--- a/matrix_client/room.py
+++ b/matrix_client/room.py
@@ -117,7 +117,7 @@ class Room(object):
         """ Add a callback handler for events going to this room.
 
         Args:
-            callback (func(roomchunk)): Callback called when an event arrives.
+            callback (func(room, event)): Callback called when an event arrives.
             event_type (str): The event_type to filter for.
         """
         self.listeners.append(
@@ -131,7 +131,7 @@ class Room(object):
         """ Add a callback handler for ephemeral events going to this room.
 
         Args:
-            callback (func(roomchunk)): Callback called when an ephemeral event arrives.
+            callback (func(room, event)): Callback called when an ephemeral event arrives.
             event_type (str): The event_type to filter for.
         """
         self.ephemeral_listeners.append(


### PR DESCRIPTION
Room listeners callbacks are called with two parameters, the first
one is the room object and the second is the event itself.
Docstring stated callbacks as one parameter functions, this patch
aligns it to the code.

Fixes: ad330ae44e27 ("matrix_client: Add support for ephemeral events")
Fixes: f160ec459cdc ("Extract Room, User to separate files from client")
Signed-off-by: Gal Pressman <galpressman@gmail.com>