### PR TITLE
Remove cpy/pst leftover in add_leave_listener()

### DIFF
--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -251,7 +251,6 @@ class MatrixClient(object):
 
     def add_leave_listener(self, callback):
         """ Add a listener that will send a callback when the client has left a room.
-        an invite request.
 
         Args:
             callback (func(room_id, room)): Callback called when the client


### PR DESCRIPTION
Removed " \n an invite request." from "MatrixClient.add_leave_listener()" docstring.

Looks like a leftover from copying/pasting from MatrixClient.add_invite_listener() docstring