### PR TITLE
matrix_client: Add room members listing

### DIFF
--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -529,3 +529,12 @@ class MatrixHttpApi(object):
         """
         return self._send("DELETE", "/directory/room/{}".format(quote(room_alias)),
                           api_path="/_matrix/client/r0")
+
+    def get_room_members(self, room_id):
+        """Get the list of members for this room.
+
+        Args:
+            room_id (str): The room to get the member events for.
+        """
+        return self._send("GET", "/rooms/{}/members".format(quote(room_id)),
+                          api_path='/_matrix/client/r0')

--- a/matrix_client/room.py
+++ b/matrix_client/room.py
@@ -374,3 +374,18 @@ class Room(object):
             return True
         except MatrixRequestError:
             return False
+
+    def get_joined_members(self):
+        """Query joined members of this room.
+
+        Returns:
+            {user_id: {"displayname": str or None}}: Dictionary of joined members.
+        """
+        response = self.client.api.get_room_members(self.room_id)
+        rtn = {
+            event["state_key"]: {
+                "displayname": event["content"].get("displayname"),
+            } for event in response["chunk"] if event["content"]["membership"] == "join"
+        }
+
+        return rtn


### PR DESCRIPTION
Please let me know if you can estimate when you will have the time to review this patch.
I'd like to use this functionality very soon and want to know whether I should implement a workaround in my project for the time being.

> api: Add /rooms/{roomId}/members endpoint.
> room: Add get_joined_members() method.
> 
> Signed-off-by: Gal Pressman <galpressman@gmail.com>