### PR TITLE
matrix_client/room: Allow changing of backfill order

### DIFF
--- a/matrix_client/room.py
+++ b/matrix_client/room.py
@@ -391,15 +391,20 @@ class Room(object):
 
         return rtn
 
-    def backfill_previous_messages(self, limit=10):
+    def backfill_previous_messages(self, reverse=False, limit=10):
         """Backfill handling of previous messages.
 
         Args:
+            reverse (bool): When false messages will be backfilled in their original
+                order (old to new), otherwise the order will be reversed (new to old).
             limit (int): Number of messages to go back.
         """
         res = self.client.api.get_room_messages(self.room_id, self.prev_batch,
                                                 direction="b", limit=limit)
-        for event in res["chunk"]:
+        events = res["chunk"]
+        if not reverse:
+            events = reversed(events)
+        for event in events:
             self._put_event(event)
 
     @property


### PR DESCRIPTION
This one is a little confusing (for me), and this code probably should've come with the patch that introduced the backfill option.

What backfill currently does is fetch the last `limit` messages using the room `prev_batch` and backward direction. This ofcourse results in messages being backfilled in their reversed order (new ones first), which is not always wanted.
This patch allows the user to manually state the order he wishes to "walk" through his previous messages.

Waiting for your opinion, sorry for the quick change 😓.