### PR TITLE
Add API methods for devices endpoint

### DIFF
--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -24,6 +24,7 @@ except ImportError:
     from urllib.parse import quote
 
 MATRIX_V2_API_PATH = "/_matrix/client/r0"
+MATRIX_UNSTABLE_API_PATH = "/_matrix/client/unstable"
 
 
 class MatrixHttpApi(object):
@@ -615,3 +616,65 @@ class MatrixHttpApi(object):
         """
         return self._send("GET", "/rooms/{}/members".format(quote(room_id)),
                           api_path=MATRIX_V2_API_PATH)
+
+    def get_devices(self):
+        """
+            Gets information about all devices for the current user
+        """
+        return self._send("GET", "/devices",
+                          api_path=MATRIX_UNSTABLE_API_PATH)
+
+    def get_device(self, device_id):
+        """
+            Gets information on a single device, by device id.
+        """
+        return self._send("GET", "/devices/%s" % device_id,
+                          api_path=MATRIX_UNSTABLE_API_PATH)
+
+    def update_device_info(self, device_id, display_name):
+        """ Update the display name of a device.
+        Args:
+            device_id (str): The device ID of the device to update.
+            display_name (str): New display name for the device.
+        """
+        content = {
+            "display_name": display_name
+        }
+        return self._send(
+            "PUT",
+            "/devices/%s" % device_id,
+            content=content,
+            api_path=MATRIX_UNSTABLE_API_PATH)
+
+    def delete_device(self, auth_body, device_id):
+        """ Deletes the given device, and invalidates any access token assoicated with it.
+        Requires Auth.
+        Args:
+            auth_body (dict): Authentication params.
+            device_id (str): The device ID of the device to delete.
+        """
+        content = {
+            "auth": auth_body
+        }
+        return self._send(
+            "DELETE",
+            "/devices/%s" % device_id,
+            content=content,
+            api_path=MATRIX_UNSTABLE_API_PATH)
+
+    def delete_devices(self, auth_body, devices):
+        """ Bulk deletion of devices.
+            Requires Auth.
+            Args:
+                auth_body (dict): Authentication params.
+                devices (list): List of device ID"s to delete.
+        """
+        content = {
+            "auth": auth_body,
+            "devices": devices
+        }
+        return self._send(
+            "POST",
+            "/delete_devices",
+            content=content,
+            api_path=MATRIX_UNSTABLE_API_PATH)


### PR DESCRIPTION
@Half-Shot Have you given any thought to how to do testing for API methods? It would be nice if we could auto-extract the paths from the specs and assert that the methods request to the correct paths.