### PR TITLE
Add testing for python 3.6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,packaging,pep8
+envlist = py27,py34,py35,py36,packaging,pep8
 
 [testenv]
 setenv =


### PR DESCRIPTION
If we say we support versions of pythoon >= 3.4, we should run tests against 3.6.