### PR TITLE
Check whether content=None before dumping it to json.

### DIFF
--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -518,7 +518,7 @@ class MatrixHttpApi(object):
 
         endpoint = self.base_url + api_path + path
 
-        if headers["Content-Type"] == "application/json":
+        if headers["Content-Type"] == "application/json" and content is not None:
             content = json.dumps(content)
 
         response = None


### PR DESCRIPTION
This can prevent the request from being added a Content-Length header
in GET methods where there's no content.

This fixes issue #113 and it's been tested with the SimpleChatClient sample.