### PR TITLE
Add handling for exceptions raised by requests library

### DIFF
--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -594,9 +594,7 @@ class MatrixHttpApi(object):
                     verify=self.validate_cert
                 )
             except requests.exceptions.RequestException as e:
-                raise MatrixHttpLibError(
-                    "Something went wrong in {} requesting {}".format(method, endpoint), e
-                )
+                raise MatrixHttpLibError(e, method, endpoint)
 
             if response.status_code == 429:
                 sleep(response.json()['retry_after_ms'] / 1000)

--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -16,7 +16,7 @@
 import json
 import requests
 from time import time, sleep
-from .errors import MatrixError, MatrixRequestError
+from .errors import MatrixError, MatrixRequestError, MatrixHttpLibError
 
 try:
     from urllib import quote
@@ -585,13 +585,18 @@ class MatrixHttpApi(object):
 
         response = None
         while True:
-            response = requests.request(
-                method, endpoint,
-                params=query_params,
-                data=content,
-                headers=headers,
-                verify=self.validate_cert
-            )
+            try:
+                response = requests.request(
+                    method, endpoint,
+                    params=query_params,
+                    data=content,
+                    headers=headers,
+                    verify=self.validate_cert
+                )
+            except requests.exceptions.RequestException as e:
+                raise MatrixHttpLibError(
+                    "Something went wrong in sending the request", e
+                )
 
             if response.status_code == 429:
                 sleep(response.json()['retry_after_ms'] / 1000)

--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -595,7 +595,7 @@ class MatrixHttpApi(object):
                 )
             except requests.exceptions.RequestException as e:
                 raise MatrixHttpLibError(
-                    "Something went wrong in sending the request", e
+                    "Something went wrong in {} requesting {}".format(method, endpoint), e
                 )
 
             if response.status_code == 429:

--- a/matrix_client/errors.py
+++ b/matrix_client/errors.py
@@ -23,6 +23,8 @@ class MatrixRequestError(MatrixError):
 class MatrixHttpLibError(MatrixError):
     """The library used for http requests raised an exception."""
 
-    def __init__(self, msg, original_exception):
-        super(MatrixHttpLibError, self).__init__(msg + ": {}".format(original_exception))
+    def __init__(self, original_exception, method, endpoint):
+        super(MatrixHttpLibError, self).__init__(
+            "Something went wrong in {} requesting {}: {}".format(original_exception)
+        )
         self.original_exception = original_exception

--- a/matrix_client/errors.py
+++ b/matrix_client/errors.py
@@ -5,6 +5,7 @@ class MatrixError(Exception):
 
 class MatrixUnexpectedResponse(MatrixError):
     """The home server gave an unexpected response. """
+
     def __init__(self, content=""):
         super(MatrixError, self).__init__(content)
         self.content = content
@@ -17,3 +18,11 @@ class MatrixRequestError(MatrixError):
         super(MatrixRequestError, self).__init__("%d: %s" % (code, content))
         self.code = code
         self.content = content
+
+
+class MatrixHttpLibError(MatrixError):
+    """The library used for http requests raised an exception."""
+
+    def __init__(self, msg, original_exception):
+        super(MatrixHttpLibError, self).__init__(msg + ": {}".format(original_exception))
+        self.original_exception = original_exception


### PR DESCRIPTION
Use of requests is an implementation detail, so we shouldn't let exceptions raised by requests leak through to any application developers.

Technically this may need a major version bump since someone may have been manually handling exceptions raised by requests. But I doubt it.