### PR TITLE
Move main api methods into transport-agnostic class

### DIFF
--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -32,7 +32,7 @@ class MatrixApi(object):
     For usage, MatrixApi must be subclassed with a valid _send method.
     """
 
-    def __init__(self, base_url, token=None, identity=None):
+    def __init__(self, base_url=None, token=None, identity=None):
         """Construct and configure the API.
 
         Args:

--- a/matrix_client/errors.py
+++ b/matrix_client/errors.py
@@ -5,6 +5,7 @@ class MatrixError(Exception):
 
 class MatrixUnexpectedResponse(MatrixError):
     """The home server gave an unexpected response. """
+
     def __init__(self, content=""):
         super(MatrixError, self).__init__(content)
         self.content = content
@@ -17,3 +18,11 @@ class MatrixRequestError(MatrixError):
         super(MatrixRequestError, self).__init__("%d: %s" % (code, content))
         self.code = code
         self.content = content
+
+
+class MatrixApiError(MatrixError):
+    """An Api method was unable to be completed successfully."""
+
+    def __init__(self, content="", api_method=""):
+        self.content = content
+        super(MatrixError, self).__init__("{}: {}".format(content, api_method))

--- a/matrix_client/errors.py
+++ b/matrix_client/errors.py
@@ -23,6 +23,8 @@ class MatrixRequestError(MatrixError):
 class MatrixApiError(MatrixError):
     """An Api method was unable to be completed successfully."""
 
-    def __init__(self, content="", api_method=""):
+    def __init__(self, content="", api_method="", raised_errors=""):
         self.content = content
-        super(MatrixError, self).__init__("{}: {}".format(content, api_method))
+        super(MatrixError, self).__init__(
+            "{}: {}\nErrors raised: {}".format(content, api_method, raised_errors)
+        )

--- a/matrix_client/utils.py
+++ b/matrix_client/utils.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Adam Beckmeyer
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from . import errors
+from .api import MatrixApi
+import functools
+
+
+class AggregateApi:
+    """Groups together multiple Api objects to call in order."""
+
+    def __init__(self, api_list):
+        """Constructs the aggregate api to look like MatrixApi.
+
+        Args:
+            api_list(iterable): Iterable of api objects to be tried in order.
+        """
+        self.apis = api_list
+        # Make methods of AggregateApi look like MatrixApi
+        method_names = (m for m in dir(MatrixApi) if not m.startswith("_"))
+        for m in method_names:
+            setattr(self, m, functools.partial(self._call_api_methods, m))
+
+    def _call_api_methods(self, method_name, *args, **kwargs):
+        """Calls method of each listed api until successful.
+
+        Args:
+            method_name(str): Method to be called on each object in self.apis
+            args: To be passed when calling method.
+            kwargs: To be passed when calling method.
+        """
+        api_methods = (getattr(api, method_name) for api in self.apis)
+        for method in api_methods:
+            try:
+                return method(*args, **kwargs)
+            except NotImplementedError:
+                pass
+
+        raise errors.MatrixApiError('Unable to complete the api method', method_name)

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -1,4 +1,6 @@
 from matrix_client.client import MatrixClient, Room, User
+from matrix_client.api import MatrixApi
+from matrix_client import errors
 import pytest
 
 
@@ -137,3 +139,10 @@ def test_remove_listener():
             break
 
     assert not found_listener, "listener was not removed properly"
+
+
+def test_aggregate_api():
+    api = MatrixApi()
+    with pytest.raises(errors.MatrixApiError):
+        client = MatrixClient("http://example.com", token="foo",
+                              user_id="@bar:example.com", apis=(api,))


### PR DESCRIPTION
Closes #37 

I was going to start working on converting the tests over to not using requests, but I'm not sure how this we should do that keeping in mind @pik's #125. I actually kind of rushed to get this one done after seeing that because I want us to have the right architecture before we really start building out our testing.