### PR TITLE
Fix timeout for sync request

### DIFF
--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -75,7 +75,7 @@ class MatrixHttpApi(object):
         """
 
         request = {
-            "timeout": timeout_ms
+            "timeout": timeout_ms/1000.0
         }
 
         if since:


### PR DESCRIPTION
Fix for: https://github.com/matrix-org/matrix-python-sdk/issues/131

According [Requests doc](http://docs.python-requests.org/en/master/user/quickstart/#timeouts) it accept timeout parameter in **seconds**.
But in [api.py#L78](https://github.com/matrix-org/matrix-python-sdk/blob/master/matrix_client/api.py#L78) to this parameter passed huge value **30000 sec = 8.3 hours** from [api.py#L63](https://github.com/matrix-org/matrix-python-sdk/blob/master/matrix_client/api.py#L63)
I think line [api.py#L78](https://github.com/matrix-org/matrix-python-sdk/blob/master/matrix_client/api.py#L78)  must be like: `"timeout": timeout_ms/1000.0`