### PR TITLE
Add **query_params to appropriate methods

### DIFF
--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -58,10 +58,12 @@ class MatrixHttpApi(object):
             limit(int): The limit= param to provide.
             **query_params: Extra parameters to be sent in the HTTP request.
                 Common values for ``query_params`` are:
-                    ts: timestamp for event
-                    user_id: user id for transaction.
+
+                | ts: timestamp for event
+                | user_id: user id for transaction.
         """
-        return self._send("GET", "/initialSync", query_params={"limit": limit},
+        query_params['limit'] = limit
+        return self._send("GET", "/initialSync",
                           query_params=query_params)
 
     def sync(self, since=None, timeout_ms=30000, filter=None,
@@ -78,8 +80,9 @@ class MatrixHttpApi(object):
             set_presence (str): Should the client be marked as "online" or" offline"
             **query_params: Extra parameters to be sent in the HTTP request.
                 Common values for ``query_params`` are:
-                    ts: timestamp for event
-                    user_id: user id for transaction.
+
+                | ts: timestamp for event
+                | user_id: user id for transaction.
         """
 
         request = query_params
@@ -129,8 +132,9 @@ class MatrixHttpApi(object):
             kind(str): Specify kind="guest" to register as guest.
             **query_params: Extra parameters to be sent in the HTTP request.
                 Common values for ``query_params`` are:
-                    ts: timestamp for event
-                    user_id: user id for transaction.
+
+                | ts: timestamp for event
+                | user_id: user id for transaction.
         """
         query_params['kind'] = kind
         return self._send(
@@ -157,11 +161,13 @@ class MatrixHttpApi(object):
 
     def logout(self, **query_params):
         """Perform /logout.
+
         Args:
             **query_params: Extra parameters to be sent in the HTTP request.
                 Common values for ``query_params`` are:
-                    ts: timestamp for event
-                    user_id: user id for transaction.
+
+                | ts: timestamp for event
+                | user_id: user id for transaction.
         """
         return self._send("POST", "/logout", query_params=query_params)
 
@@ -174,8 +180,9 @@ class MatrixHttpApi(object):
             invitees(list<str>): Optional. The list of user IDs to invite.
             **query_params: Extra parameters to be sent in the HTTP request.
                 Common values for ``query_params`` are:
-                    ts: timestamp for event
-                    user_id: user id for transaction.
+
+                | ts: timestamp for event
+                | user_id: user id for transaction.
         """
         content = {
             "visibility": "public" if is_public else "private"
@@ -193,8 +200,9 @@ class MatrixHttpApi(object):
             room_id_or_alias(str): The room ID or room alias to join.
             **query_params: Extra parameters to be sent in the HTTP request.
                 Common values for ``query_params`` are:
-                    ts: timestamp for event
-                    user_id: user id for transaction.
+
+                | ts: timestamp for event
+                | user_id: user id for transaction.
         """
         if not room_id_or_alias:
             raise MatrixError("No alias or room ID to join.")
@@ -212,8 +220,9 @@ class MatrixHttpApi(object):
             timeout(int): Optional. The 'timeout' query parameter.
             **query_params: Extra parameters to be sent in the HTTP request.
                 Common values for ``query_params`` are:
-                    ts: timestamp for event
-                    user_id: user id for transaction.
+
+                | ts: timestamp for event
+                | user_id: user id for transaction.
         """
         params = {
             "timeout": timeout,
@@ -237,8 +246,9 @@ class MatrixHttpApi(object):
             state_key(str): Optional. The state key for the event.
             **query_params: Extra parameters to be sent in the HTTP request.
                 Common values for ``query_params`` are:
-                    ts: timestamp for event
-                    user_id: user id for transaction.
+
+                | ts: timestamp for event
+                | user_id: user id for transaction.
         """
         path = "/rooms/%s/state/%s" % (
             quote(room_id), quote(event_type),
@@ -258,8 +268,9 @@ class MatrixHttpApi(object):
             txn_id(int): Optional. The transaction ID to use.
             **query_params: Extra parameters to be sent in the HTTP request.
                 Common values for ``query_params`` are:
-                    ts: timestamp for event
-                    user_id: user id for transaction.
+
+                | ts: timestamp for event
+                | user_id: user id for transaction.
         """
         if not txn_id:
             txn_id = str(self.txn_id) + str(int(time() * 1000))
@@ -327,8 +338,9 @@ class MatrixHttpApi(object):
             thumb_info(dict): Metadata about the thumbnail, type ImageInfo.
             **query_params: Extra parameters to be sent in the HTTP request.
                 Common values for ``query_params`` are:
-                    ts: timestamp for event
-                    user_id: user id for transaction.
+
+                | ts: timestamp for event
+                | user_id: user id for transaction.
         """
         content_pack = {
             "geo_uri": geo_uri,
@@ -352,8 +364,9 @@ class MatrixHttpApi(object):
             text_content(str): The m.text body to send.
             **query_params: Extra parameters to be sent in the HTTP request.
                 Common values for ``query_params`` are:
-                    ts: timestamp for event
-                    user_id: user id for transaction.
+
+                | ts: timestamp for event
+                | user_id: user id for transaction.
         """
         return self.send_message_event(
             room_id, "m.room.message",
@@ -369,8 +382,9 @@ class MatrixHttpApi(object):
             text_content(str): The m.emote body to send.
             **query_params: Extra parameters to be sent in the HTTP request.
                 Common values for ``query_params`` are:
-                    ts: timestamp for event
-                    user_id: user id for transaction.
+
+                | ts: timestamp for event
+                | user_id: user id for transaction.
         """
         return self.send_message_event(
             room_id, "m.room.message",
@@ -386,8 +400,9 @@ class MatrixHttpApi(object):
             text_content(str): The m.notice body to send.
             **query_params: Extra parameters to be sent in the HTTP request.
                 Common values for ``query_params`` are:
-                    ts: timestamp for event
-                    user_id: user id for transaction.
+
+                | ts: timestamp for event
+                | user_id: user id for transaction.
         """
         body = {
             "msgtype": "m.notice",
@@ -408,8 +423,9 @@ class MatrixHttpApi(object):
             to (str): The token to stop returning events at.
             **query_params: Extra parameters to be sent in the HTTP request.
                 Common values for ``query_params`` are:
-                    ts: timestamp for event
-                    user_id: user id for transaction.
+
+                | ts: timestamp for event
+                | user_id: user id for transaction.
         """
 
         query_params.update({
@@ -432,8 +448,9 @@ class MatrixHttpApi(object):
             room_id(str): The room ID
             **query_params: Extra parameters to be sent in the HTTP request.
                 Common values for ``query_params`` are:
-                    ts: timestamp for event
-                    user_id: user id for transaction.
+
+                | ts: timestamp for event
+                | user_id: user id for transaction.
         """
         return self._send("GET", "/rooms/" + room_id + "/state/m.room.name",
                           query_params=query_params)
@@ -445,8 +462,9 @@ class MatrixHttpApi(object):
             name(str): The new room name
             **query_params: Extra parameters to be sent in the HTTP request.
                 Common values for ``query_params`` are:
-                    ts: timestamp for event
-                    user_id: user id for transaction.
+
+                | ts: timestamp for event
+                | user_id: user id for transaction.
         """
         body = {
             "name": name
@@ -460,8 +478,9 @@ class MatrixHttpApi(object):
             room_id(str): The room ID
             **query_params: Extra parameters to be sent in the HTTP request.
                 Common values for ``query_params`` are:
-                    ts: timestamp for event
-                    user_id: user id for transaction.
+
+                | ts: timestamp for event
+                | user_id: user id for transaction.
         """
         return self._send("GET", "/rooms/" + room_id + "/state/m.room.topic",
                           query_params=query_params)
@@ -473,8 +492,9 @@ class MatrixHttpApi(object):
             topic(str): The new room topic
             **query_params: Extra parameters to be sent in the HTTP request.
                 Common values for ``query_params`` are:
-                    ts: timestamp for event
-                    user_id: user id for transaction.
+
+                | ts: timestamp for event
+                | user_id: user id for transaction.
         """
         body = {
             "topic": topic
@@ -535,8 +555,9 @@ class MatrixHttpApi(object):
             room_id(str): The room ID
             **query_params: Extra parameters to be sent in the HTTP request.
                 Common values for ``query_params`` are:
-                    ts: timestamp for event
-                    user_id: user id for transaction.
+
+                | ts: timestamp for event
+                | user_id: user id for transaction.
         """
         return self._send("POST", "/rooms/" + room_id + "/leave", {},
                           query_params=query_params)
@@ -666,8 +687,9 @@ class MatrixHttpApi(object):
             room_id(str): The room ID
             **query_params: Extra parameters to be sent in the HTTP request.
                 Common values for ``query_params`` are:
-                    ts: timestamp for event
-                    user_id: user id for transaction.
+
+                | ts: timestamp for event
+                | user_id: user id for transaction.
         """
         return self._send("GET", "/rooms/" + room_id + "/state",
                           query_params=query_params)

--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -86,23 +86,22 @@ class MatrixHttpApi(object):
                 | user_id: user id for transaction.
         """
 
-        request = query_params
         # non-integer timeouts appear to cause issues
-        request["timeout"] = int(timeout_ms)
+        query_params["timeout"] = int(timeout_ms)
 
         if since:
-            request["since"] = since
+            query_params["since"] = since
 
         if filter:
-            request["filter"] = filter
+            query_params["filter"] = filter
 
         if full_state:
-            request["full_state"] = full_state
+            query_params["full_state"] = full_state
 
         if set_presence:
-            request["set_presence"] = set_presence
+            query_params["set_presence"] = set_presence
 
-        return self._send("GET", "/sync", query_params=request,
+        return self._send("GET", "/sync", query_params=query_params,
                           api_path=MATRIX_V2_API_PATH)
 
     def validate_certificate(self, valid):

--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -86,6 +86,7 @@ class MatrixHttpApi(object):
         """
 
         request = query_params
+        # non-integer timeouts appear to cause issues
         request["timeout"] = int(timeout_ms)
 
         if since:
@@ -759,7 +760,7 @@ class MatrixHttpApi(object):
         return self._send(
             "POST", "",
             content=content,
-            query_params=query_params
+            query_params=query_params,
             headers={"Content-Type": content_type},
             api_path="/_matrix/media/r0/upload",
         )

--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -51,16 +51,17 @@ class MatrixHttpApi(object):
         self.txn_id = 0
         self.validate_cert = True
 
-    def initial_sync(self, limit=1, **query_params):
+    def initial_sync(self, limit=1, query_params=None):
         """ Deprecated. Use sync instead.
         Perform /initialSync.
 
         Args:
             limit(int): The limit= param to provide.
-            **query_params: Extra parameters to be sent in the HTTP request.
+            query_params: Extra parameters to be sent in the HTTP request,
+
+                These parameters are normally only used for application services.
                 Common values for ``query_params`` are:
 
-                | ts: timestamp for event
                 | user_id: user id for transaction.
         """
         query_params['limit'] = limit
@@ -68,7 +69,7 @@ class MatrixHttpApi(object):
                           query_params=query_params)
 
     def sync(self, since=None, timeout_ms=30000, filter=None,
-             full_state=None, set_presence=None, **query_params):
+             full_state=None, set_presence=None, query_params=None):
         """ Perform a sync request.
 
         Args:
@@ -79,7 +80,9 @@ class MatrixHttpApi(object):
             full_state (bool): Return the full state for every room the user has joined
                 Defaults to false.
             set_presence (str): Should the client be marked as "online" or" offline"
-            **query_params: Extra parameters to be sent in the HTTP request.
+            query_params: Extra parameters to be sent in the HTTP request,
+
+                These parameters are normally only used for application services.
                 Common values for ``query_params`` are:
 
                 | ts: timestamp for event
@@ -107,7 +110,7 @@ class MatrixHttpApi(object):
     def validate_certificate(self, valid):
         self.validate_cert = valid
 
-    def register(self, content={}, kind='user', **query_params):
+    def register(self, content={}, kind='user', query_params=None):
         """Performs /register.
 
         Args:
@@ -131,10 +134,11 @@ class MatrixHttpApi(object):
                         to complete. "m.login.dummy" is the only non-interactive type.
 
             kind(str): Specify kind="guest" to register as guest.
-            **query_params: Extra parameters to be sent in the HTTP request.
+            query_params: Extra parameters to be sent in the HTTP request,
+
+                These parameters are normally only used for application services.
                 Common values for ``query_params`` are:
 
-                | ts: timestamp for event
                 | user_id: user id for transaction.
         """
         query_params['kind'] = kind
@@ -160,11 +164,13 @@ class MatrixHttpApi(object):
 
         return self._send("POST", "/login", content)
 
-    def logout(self, **query_params):
+    def logout(self, query_params=None):
         """Perform /logout.
 
         Args:
-            **query_params: Extra parameters to be sent in the HTTP request.
+            query_params: Extra parameters to be sent in the HTTP request,
+
+                These parameters are normally only used for application services.
                 Common values for ``query_params`` are:
 
                 | ts: timestamp for event
@@ -172,14 +178,16 @@ class MatrixHttpApi(object):
         """
         return self._send("POST", "/logout", query_params=query_params)
 
-    def create_room(self, alias=None, is_public=False, invitees=(), **query_params):
+    def create_room(self, alias=None, is_public=False, invitees=(), query_params=None):
         """Perform /createRoom.
 
         Args:
             alias(str): Optional. The room alias name to set for this room.
             is_public(bool): Optional. The public/private visibility.
             invitees(list<str>): Optional. The list of user IDs to invite.
-            **query_params: Extra parameters to be sent in the HTTP request.
+            query_params: Extra parameters to be sent in the HTTP request,
+
+                These parameters are normally only used for application services.
                 Common values for ``query_params`` are:
 
                 | ts: timestamp for event
@@ -194,12 +202,14 @@ class MatrixHttpApi(object):
             content["invite"] = invitees
         return self._send("POST", "/createRoom", content, query_params=query_params)
 
-    def join_room(self, room_id_or_alias, **query_params):
+    def join_room(self, room_id_or_alias, query_params=None):
         """Performs /join/$room_id
 
         Args:
             room_id_or_alias(str): The room ID or room alias to join.
-            **query_params: Extra parameters to be sent in the HTTP request.
+            query_params: Extra parameters to be sent in the HTTP request,
+
+                These parameters are normally only used for application services.
                 Common values for ``query_params`` are:
 
                 | ts: timestamp for event
@@ -212,14 +222,16 @@ class MatrixHttpApi(object):
 
         return self._send("POST", path, query_params=query_params)
 
-    def event_stream(self, from_token, timeout=30000, **query_params):
+    def event_stream(self, from_token, timeout=30000, query_params=None):
         """ Deprecated. Use sync instead.
         Performs /events
 
         Args:
             from_token(str): The 'from' query parameter.
             timeout(int): Optional. The 'timeout' query parameter.
-            **query_params: Extra parameters to be sent in the HTTP request.
+            query_params: Extra parameters to be sent in the HTTP request,
+
+                These parameters are normally only used for application services.
                 Common values for ``query_params`` are:
 
                 | ts: timestamp for event
@@ -237,7 +249,7 @@ class MatrixHttpApi(object):
             query_params=query_params)
 
     def send_state_event(self, room_id, event_type, content, state_key="",
-                         **query_params):
+                         query_params=None):
         """Perform PUT /rooms/$room_id/state/$event_type
 
         Args:
@@ -245,7 +257,9 @@ class MatrixHttpApi(object):
             event_type(str): The state event type to send.
             content(dict): The JSON content to send.
             state_key(str): Optional. The state key for the event.
-            **query_params: Extra parameters to be sent in the HTTP request.
+            query_params: Extra parameters to be sent in the HTTP request,
+
+                These parameters are normally only used for application services.
                 Common values for ``query_params`` are:
 
                 | ts: timestamp for event
@@ -259,7 +273,7 @@ class MatrixHttpApi(object):
         return self._send("PUT", path, content, query_params=query_params)
 
     def send_message_event(self, room_id, event_type, content, txn_id=None,
-                           **query_params):
+                           query_params=None):
         """Perform PUT /rooms/$room_id/send/$event_type
 
         Args:
@@ -267,7 +281,9 @@ class MatrixHttpApi(object):
             event_type(str): The event type to send.
             content(dict): The JSON content to send.
             txn_id(int): Optional. The transaction ID to use.
-            **query_params: Extra parameters to be sent in the HTTP request.
+            query_params: Extra parameters to be sent in the HTTP request,
+
+                These parameters are normally only used for application services.
                 Common values for ``query_params`` are:
 
                 | ts: timestamp for event
@@ -312,7 +328,7 @@ class MatrixHttpApi(object):
     # extra information should be supplied, see
     # https://matrix.org/docs/spec/r0.0.1/client_server.html
     def send_content(self, room_id, item_url, item_name, msg_type,
-                     extra_information=None, **query_params):
+                     extra_information=None, query_params=None):
         if extra_information is None:
             extra_information = {}
 
@@ -328,7 +344,7 @@ class MatrixHttpApi(object):
 
     # http://matrix.org/docs/spec/client_server/r0.2.0.html#m-location
     def send_location(self, room_id, geo_uri, name, thumb_url=None, thumb_info=None,
-                      **query_params):
+                      query_params=None):
         """Send m.location message event
 
         Args:
@@ -337,7 +353,9 @@ class MatrixHttpApi(object):
             name(str): Description for the location.
             thumb_url(str): URL to the thumbnail of the location.
             thumb_info(dict): Metadata about the thumbnail, type ImageInfo.
-            **query_params: Extra parameters to be sent in the HTTP request.
+            query_params: Extra parameters to be sent in the HTTP request,
+
+                These parameters are normally only used for application services.
                 Common values for ``query_params`` are:
 
                 | ts: timestamp for event
@@ -357,13 +375,15 @@ class MatrixHttpApi(object):
                                        query_params=query_params)
 
     def send_message(self, room_id, text_content, msgtype="m.text",
-                     **query_params):
+                     query_params=None):
         """Perform PUT /rooms/$room_id/send/m.room.message
 
         Args:
             room_id(str): The room ID to send the event in.
             text_content(str): The m.text body to send.
-            **query_params: Extra parameters to be sent in the HTTP request.
+            query_params: Extra parameters to be sent in the HTTP request,
+
+                These parameters are normally only used for application services.
                 Common values for ``query_params`` are:
 
                 | ts: timestamp for event
@@ -375,13 +395,15 @@ class MatrixHttpApi(object):
             query_params=query_params
         )
 
-    def send_emote(self, room_id, text_content, **query_params):
+    def send_emote(self, room_id, text_content, query_params=None):
         """Perform PUT /rooms/$room_id/send/m.room.message with m.emote msgtype
 
         Args:
             room_id(str): The room ID to send the event in.
             text_content(str): The m.emote body to send.
-            **query_params: Extra parameters to be sent in the HTTP request.
+            query_params: Extra parameters to be sent in the HTTP request,
+
+                These parameters are normally only used for application services.
                 Common values for ``query_params`` are:
 
                 | ts: timestamp for event
@@ -393,13 +415,15 @@ class MatrixHttpApi(object):
             query_params=query_params
         )
 
-    def send_notice(self, room_id, text_content, **query_params):
+    def send_notice(self, room_id, text_content, query_params=None):
         """Perform PUT /rooms/$room_id/send/m.room.message with m.notice msgtype
 
         Args:
             room_id(str): The room ID to send the event in.
             text_content(str): The m.notice body to send.
-            **query_params: Extra parameters to be sent in the HTTP request.
+            query_params: Extra parameters to be sent in the HTTP request,
+
+                These parameters are normally only used for application services.
                 Common values for ``query_params`` are:
 
                 | ts: timestamp for event
@@ -413,7 +437,7 @@ class MatrixHttpApi(object):
                                        query_params=query_params)
 
     def get_room_messages(self, room_id, token, direction, limit=10, to=None,
-                          **query_params):
+                          query_params=None):
         """Perform GET /rooms/{roomId}/messages.
 
         Args:
@@ -422,7 +446,9 @@ class MatrixHttpApi(object):
             direction (str):  The direction to return events from. One of: ["b", "f"].
             limit (int): The maximum number of events to return.
             to (str): The token to stop returning events at.
-            **query_params: Extra parameters to be sent in the HTTP request.
+            query_params: Extra parameters to be sent in the HTTP request,
+
+                These parameters are normally only used for application services.
                 Common values for ``query_params`` are:
 
                 | ts: timestamp for event
@@ -443,11 +469,13 @@ class MatrixHttpApi(object):
                           api_path="/_matrix/client/r0",
                           query_params=query_params)
 
-    def get_room_name(self, room_id, **query_params):
+    def get_room_name(self, room_id, query_params=None):
         """Perform GET /rooms/$room_id/state/m.room.name
         Args:
             room_id(str): The room ID
-            **query_params: Extra parameters to be sent in the HTTP request.
+            query_params: Extra parameters to be sent in the HTTP request,
+
+                These parameters are normally only used for application services.
                 Common values for ``query_params`` are:
 
                 | ts: timestamp for event
@@ -456,12 +484,14 @@ class MatrixHttpApi(object):
         return self._send("GET", "/rooms/" + room_id + "/state/m.room.name",
                           query_params=query_params)
 
-    def set_room_name(self, room_id, name, **query_params):
+    def set_room_name(self, room_id, name, query_params=None):
         """Perform PUT /rooms/$room_id/state/m.room.name
         Args:
             room_id(str): The room ID
             name(str): The new room name
-            **query_params: Extra parameters to be sent in the HTTP request.
+            query_params: Extra parameters to be sent in the HTTP request,
+
+                These parameters are normally only used for application services.
                 Common values for ``query_params`` are:
 
                 | ts: timestamp for event
@@ -473,11 +503,13 @@ class MatrixHttpApi(object):
         return self.send_state_event(room_id, "m.room.name", body,
                                      query_params=query_params)
 
-    def get_room_topic(self, room_id, **query_params):
+    def get_room_topic(self, room_id, query_params=None):
         """Perform GET /rooms/$room_id/state/m.room.topic
         Args:
             room_id(str): The room ID
-            **query_params: Extra parameters to be sent in the HTTP request.
+            query_params: Extra parameters to be sent in the HTTP request,
+
+                These parameters are normally only used for application services.
                 Common values for ``query_params`` are:
 
                 | ts: timestamp for event
@@ -486,12 +518,14 @@ class MatrixHttpApi(object):
         return self._send("GET", "/rooms/" + room_id + "/state/m.room.topic",
                           query_params=query_params)
 
-    def set_room_topic(self, room_id, topic, **query_params):
+    def set_room_topic(self, room_id, topic, query_params=None):
         """Perform PUT /rooms/$room_id/state/m.room.topic
         Args:
             room_id(str): The room ID
             topic(str): The new room topic
-            **query_params: Extra parameters to be sent in the HTTP request.
+            query_params: Extra parameters to be sent in the HTTP request,
+
+                These parameters are normally only used for application services.
                 Common values for ``query_params`` are:
 
                 | ts: timestamp for event
@@ -550,11 +584,13 @@ class MatrixHttpApi(object):
 
         return self.send_state_event(room_id, "m.room.power_levels", content)
 
-    def leave_room(self, room_id, **query_params):
+    def leave_room(self, room_id, query_params=None):
         """Perform POST /rooms/$room_id/leave
         Args:
             room_id(str): The room ID
-            **query_params: Extra parameters to be sent in the HTTP request.
+            query_params: Extra parameters to be sent in the HTTP request,
+
+                These parameters are normally only used for application services.
                 Common values for ``query_params`` are:
 
                 | ts: timestamp for event
@@ -599,7 +635,7 @@ class MatrixHttpApi(object):
         )
 
     def set_membership(self, room_id, user_id, membership, reason="", profile={},
-                       **query_params):
+                       query_params=None):
         """Perform PUT /rooms/$room_id/state/m.room.member/$user_id
         Args:
             room_id(str): The room ID
@@ -682,11 +718,13 @@ class MatrixHttpApi(object):
             account_data
         )
 
-    def get_room_state(self, room_id, **query_params):
+    def get_room_state(self, room_id, query_params=None):
         """Perform GET /rooms/$room_id/state
         Args:
             room_id(str): The room ID
-            **query_params: Extra parameters to be sent in the HTTP request.
+            query_params: Extra parameters to be sent in the HTTP request,
+
+                These parameters are normally only used for application services.
                 Common values for ``query_params`` are:
 
                 | ts: timestamp for event
@@ -759,7 +797,7 @@ class MatrixHttpApi(object):
 
         return response.json()
 
-    def media_upload(self, content, content_type, **query_params):
+    def media_upload(self, content, content_type, query_params=None):
         return self._send(
             "POST", "",
             content=content,
@@ -790,7 +828,7 @@ class MatrixHttpApi(object):
         else:
             raise ValueError("MXC URL did not begin with 'mxc://'")
 
-    def get_room_id(self, room_alias, **query_params):
+    def get_room_id(self, room_alias, query_params=None):
         """Get room id from its alias
 
         Args:
@@ -803,7 +841,7 @@ class MatrixHttpApi(object):
                              query_params=query_params)
         return content.get("room_id", None)
 
-    def set_room_alias(self, room_id, room_alias, **query_params):
+    def set_room_alias(self, room_id, room_alias, query_params=None):
         """Set alias to room id
 
         Args:
@@ -817,7 +855,7 @@ class MatrixHttpApi(object):
         return self._send("PUT", "/directory/room/{}".format(quote(room_alias)),
                           content=data, query_params=query_params)
 
-    def remove_room_alias(self, room_alias, **query_params):
+    def remove_room_alias(self, room_alias, query_params=None):
         """Remove mapping of an alias
 
         Args:
@@ -829,7 +867,7 @@ class MatrixHttpApi(object):
         return self._send("DELETE", "/directory/room/{}".format(quote(room_alias)),
                           query_params=query_params)
 
-    def get_room_members(self, room_id, **query_params):
+    def get_room_members(self, room_id, query_params=None):
         """Get the list of members for this room.
 
         Args:

--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -51,7 +51,7 @@ class MatrixHttpApi(object):
         self.txn_id = 0
         self.validate_cert = True
 
-    def initial_sync(self, limit=1, query_params=None):
+    def initial_sync(self, limit=1, query_params={}):
         """ Deprecated. Use sync instead.
         Perform /initialSync.
 
@@ -69,7 +69,7 @@ class MatrixHttpApi(object):
                           query_params=query_params)
 
     def sync(self, since=None, timeout_ms=30000, filter=None,
-             full_state=None, set_presence=None, query_params=None):
+             full_state=None, set_presence=None, query_params={}):
         """ Perform a sync request.
 
         Args:
@@ -110,7 +110,7 @@ class MatrixHttpApi(object):
     def validate_certificate(self, valid):
         self.validate_cert = valid
 
-    def register(self, content={}, kind='user', query_params=None):
+    def register(self, content={}, kind='user', query_params={}):
         """Performs /register.
 
         Args:
@@ -164,7 +164,7 @@ class MatrixHttpApi(object):
 
         return self._send("POST", "/login", content)
 
-    def logout(self, query_params=None):
+    def logout(self, query_params={}):
         """Perform /logout.
 
         Args:
@@ -178,7 +178,7 @@ class MatrixHttpApi(object):
         """
         return self._send("POST", "/logout", query_params=query_params)
 
-    def create_room(self, alias=None, is_public=False, invitees=(), query_params=None):
+    def create_room(self, alias=None, is_public=False, invitees=(), query_params={}):
         """Perform /createRoom.
 
         Args:
@@ -202,7 +202,7 @@ class MatrixHttpApi(object):
             content["invite"] = invitees
         return self._send("POST", "/createRoom", content, query_params=query_params)
 
-    def join_room(self, room_id_or_alias, query_params=None):
+    def join_room(self, room_id_or_alias, query_params={}):
         """Performs /join/$room_id
 
         Args:
@@ -222,7 +222,7 @@ class MatrixHttpApi(object):
 
         return self._send("POST", path, query_params=query_params)
 
-    def event_stream(self, from_token, timeout=30000, query_params=None):
+    def event_stream(self, from_token, timeout=30000, query_params={}):
         """ Deprecated. Use sync instead.
         Performs /events
 
@@ -246,7 +246,7 @@ class MatrixHttpApi(object):
             query_params=query_params)
 
     def send_state_event(self, room_id, event_type, content, state_key="",
-                         query_params=None):
+                         query_params={}):
         """Perform PUT /rooms/$room_id/state/$event_type
 
         Args:
@@ -270,7 +270,7 @@ class MatrixHttpApi(object):
         return self._send("PUT", path, content, query_params=query_params)
 
     def send_message_event(self, room_id, event_type, content, txn_id=None,
-                           query_params=None):
+                           query_params={}):
         """Perform PUT /rooms/$room_id/send/$event_type
 
         Args:
@@ -325,7 +325,7 @@ class MatrixHttpApi(object):
     # extra information should be supplied, see
     # https://matrix.org/docs/spec/r0.0.1/client_server.html
     def send_content(self, room_id, item_url, item_name, msg_type,
-                     extra_information=None, query_params=None):
+                     extra_information=None, query_params={}):
         if extra_information is None:
             extra_information = {}
 
@@ -341,7 +341,7 @@ class MatrixHttpApi(object):
 
     # http://matrix.org/docs/spec/client_server/r0.2.0.html#m-location
     def send_location(self, room_id, geo_uri, name, thumb_url=None, thumb_info=None,
-                      query_params=None):
+                      query_params={}):
         """Send m.location message event
 
         Args:
@@ -372,7 +372,7 @@ class MatrixHttpApi(object):
                                        query_params=query_params)
 
     def send_message(self, room_id, text_content, msgtype="m.text",
-                     query_params=None):
+                     query_params={}):
         """Perform PUT /rooms/$room_id/send/m.room.message
 
         Args:
@@ -392,7 +392,7 @@ class MatrixHttpApi(object):
             query_params=query_params
         )
 
-    def send_emote(self, room_id, text_content, query_params=None):
+    def send_emote(self, room_id, text_content, query_params={}):
         """Perform PUT /rooms/$room_id/send/m.room.message with m.emote msgtype
 
         Args:
@@ -412,7 +412,7 @@ class MatrixHttpApi(object):
             query_params=query_params
         )
 
-    def send_notice(self, room_id, text_content, query_params=None):
+    def send_notice(self, room_id, text_content, query_params={}):
         """Perform PUT /rooms/$room_id/send/m.room.message with m.notice msgtype
 
         Args:
@@ -434,7 +434,7 @@ class MatrixHttpApi(object):
                                        query_params=query_params)
 
     def get_room_messages(self, room_id, token, direction, limit=10, to=None,
-                          query_params=None):
+                          query_params={}):
         """Perform GET /rooms/{roomId}/messages.
 
         Args:
@@ -466,7 +466,7 @@ class MatrixHttpApi(object):
                           api_path="/_matrix/client/r0",
                           query_params=query_params)
 
-    def get_room_name(self, room_id, query_params=None):
+    def get_room_name(self, room_id, query_params={}):
         """Perform GET /rooms/$room_id/state/m.room.name
         Args:
             room_id(str): The room ID
@@ -481,7 +481,7 @@ class MatrixHttpApi(object):
         return self._send("GET", "/rooms/" + room_id + "/state/m.room.name",
                           query_params=query_params)
 
-    def set_room_name(self, room_id, name, query_params=None):
+    def set_room_name(self, room_id, name, query_params={}):
         """Perform PUT /rooms/$room_id/state/m.room.name
         Args:
             room_id(str): The room ID
@@ -500,7 +500,7 @@ class MatrixHttpApi(object):
         return self.send_state_event(room_id, "m.room.name", body,
                                      query_params=query_params)
 
-    def get_room_topic(self, room_id, query_params=None):
+    def get_room_topic(self, room_id, query_params={}):
         """Perform GET /rooms/$room_id/state/m.room.topic
         Args:
             room_id(str): The room ID
@@ -515,7 +515,7 @@ class MatrixHttpApi(object):
         return self._send("GET", "/rooms/" + room_id + "/state/m.room.topic",
                           query_params=query_params)
 
-    def set_room_topic(self, room_id, topic, query_params=None):
+    def set_room_topic(self, room_id, topic, query_params={}):
         """Perform PUT /rooms/$room_id/state/m.room.topic
         Args:
             room_id(str): The room ID
@@ -581,7 +581,7 @@ class MatrixHttpApi(object):
 
         return self.send_state_event(room_id, "m.room.power_levels", content)
 
-    def leave_room(self, room_id, query_params=None):
+    def leave_room(self, room_id, query_params={}):
         """Perform POST /rooms/$room_id/leave
         Args:
             room_id(str): The room ID
@@ -632,7 +632,7 @@ class MatrixHttpApi(object):
         )
 
     def set_membership(self, room_id, user_id, membership, reason="", profile={},
-                       query_params=None):
+                       query_params={}):
         """Perform PUT /rooms/$room_id/state/m.room.member/$user_id
         Args:
             room_id(str): The room ID
@@ -715,7 +715,7 @@ class MatrixHttpApi(object):
             account_data
         )
 
-    def get_room_state(self, room_id, query_params=None):
+    def get_room_state(self, room_id, query_params={}):
         """Perform GET /rooms/$room_id/state
         Args:
             room_id(str): The room ID
@@ -794,7 +794,7 @@ class MatrixHttpApi(object):
 
         return response.json()
 
-    def media_upload(self, content, content_type, query_params=None):
+    def media_upload(self, content, content_type, query_params={}):
         return self._send(
             "POST", "",
             content=content,
@@ -825,7 +825,7 @@ class MatrixHttpApi(object):
         else:
             raise ValueError("MXC URL did not begin with 'mxc://'")
 
-    def get_room_id(self, room_alias, query_params=None):
+    def get_room_id(self, room_alias, query_params={}):
         """Get room id from its alias
 
         Args:
@@ -838,7 +838,7 @@ class MatrixHttpApi(object):
                              query_params=query_params)
         return content.get("room_id", None)
 
-    def set_room_alias(self, room_id, room_alias, query_params=None):
+    def set_room_alias(self, room_id, room_alias, query_params={}):
         """Set alias to room id
 
         Args:
@@ -852,7 +852,7 @@ class MatrixHttpApi(object):
         return self._send("PUT", "/directory/room/{}".format(quote(room_alias)),
                           content=data, query_params=query_params)
 
-    def remove_room_alias(self, room_alias, query_params=None):
+    def remove_room_alias(self, room_alias, query_params={}):
         """Remove mapping of an alias
 
         Args:
@@ -864,7 +864,7 @@ class MatrixHttpApi(object):
         return self._send("DELETE", "/directory/room/{}".format(quote(room_alias)),
                           query_params=query_params)
 
-    def get_room_members(self, room_id, query_params=None):
+    def get_room_members(self, room_id, query_params={}):
         """Get the list of members for this room.
 
         Args:

--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -237,11 +237,8 @@ class MatrixHttpApi(object):
                 | ts: timestamp for event
                 | user_id: user id for transaction.
         """
-        params = {
-            "timeout": timeout,
-            "from": from_token
-        }
-        query_params.update(params)
+        query_params['timeout'] = int(timeout)
+        query_parms['from'] = from_token
 
         path = "/events"
         return self._send(

--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -37,7 +37,7 @@ class MatrixHttpApi(object):
     For room and sync handling, consider using MatrixClient.
     """
 
-    def __init__(self, base_url, token=None):
+    def __init__(self, base_url, token=None, identity=None):
         """Construct and configure the HTTP API.
 
         Args:
@@ -47,6 +47,7 @@ class MatrixHttpApi(object):
         """
         self.base_url = base_url
         self.token = token
+        self.identity = identity
         self.txn_id = 0
         self.validate_cert = True
 
@@ -727,6 +728,9 @@ class MatrixHttpApi(object):
 
         query_params["access_token"] = self.token
         endpoint = self.base_url + api_path + path
+
+        if self.identity and "user_id" not in query_params:
+            query_params["user_id"] = self.identity
 
         if headers["Content-Type"] == "application/json" and content is not None:
             content = json.dumps(content)


### PR DESCRIPTION
This now adds `**query_params` to most methods to allow specification of appservice parameters like `ts` and `user_id`.

It also does a bunch of documentation updates and moves from `sphinxcontrib.napoleon` to `sphinx.ext.napoleon`.

*This introduces a breaking change of `timestamp=` to `ts=`.*

Signed-off-by: Stuart Mumford <stuart@cadair.com> 