### PR TITLE
Adding request timeout

### DIFF
--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -560,6 +560,8 @@ class MatrixHttpApi(object):
 
         if headers["Content-Type"] == "application/json" and content is not None:
             content = json.dumps(content)
+            
+        request_timeout = 10.0 + query_params.get("timeout", 30000) / 1000
 
         response = None
         while True:
@@ -568,7 +570,8 @@ class MatrixHttpApi(object):
                 params=query_params,
                 data=content,
                 headers=headers,
-                verify=self.validate_cert
+                verify=self.validate_cert,
+                timeout=request_timeout
             )
 
             if response.status_code == 429:

--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -360,9 +360,7 @@ class MatrixClient(object):
             except MatrixRequestError as e:
                 logger.warning("A MatrixRequestError occured during sync.")
                 if e.code >= 500:
-                    logger.warning("Problem occured serverside. Waiting %i seconds",
-                                   bad_sync_timeout)
-                    sleep_bad_sync_timeout = True
+                    sleep_bad_sync = True
                 else:
                     raise e
             except requests.exceptions.ReadTimeout as e:
@@ -378,6 +376,8 @@ class MatrixClient(object):
                 else:
                     raise
             if sleep_bad_sync:
+                logger.warning("Waiting %i seconds until next sync.",
+                               bad_sync_timeout)
                 sleep(bad_sync_timeout)
                 bad_sync_timeout = min(bad_sync_timeout * 2,
                                        self.bad_sync_timeout_limit)

--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -19,7 +19,7 @@ from .user import User
 from threading import Thread
 from time import sleep
 from uuid import uuid4
-from requests.exceptions import ReadTimeout
+import requests
 import logging
 import sys
 
@@ -366,8 +366,12 @@ class MatrixClient(object):
                                            self.bad_sync_timeout_limit)
                 else:
                     raise e
-            except ReadTimeout as e:
-                logger.warning("A ReadTimeout exception occured during sync.")
+            except requests.exceptions.ReadTimeout as e:
+                logger.warning("A ReadTimeout occured during sync.")
+                bad_sync_timeout = min(bad_sync_timeout * 2,
+                                       self.bad_sync_timeout_limit)
+            except requests.exceptions.ConnectionError as e:
+                logger.warning("A ConnectionError occured during sync.")
                 bad_sync_timeout = min(bad_sync_timeout * 2,
                                        self.bad_sync_timeout_limit)
             except Exception as e:

--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -365,6 +365,10 @@ class MatrixClient(object):
                                            self.bad_sync_timeout_limit)
                 else:
                     raise e
+            except requests.exceptions.ReadTimeout as e:
+                logger.warning("A ReadTimeout exception occured during sync.")
+                bad_sync_timeout = min(bad_sync_timeout * 2,
+                                       self.bad_sync_timeout_limit)
             except Exception as e:
                 logger.exception("Exception thrown during sync")
                 if exception_handler is not None:

--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -19,6 +19,7 @@ from .user import User
 from threading import Thread
 from time import sleep
 from uuid import uuid4
+from requests.exceptions import ReadTimeout
 import logging
 import sys
 
@@ -365,7 +366,7 @@ class MatrixClient(object):
                                            self.bad_sync_timeout_limit)
                 else:
                     raise e
-            except requests.exceptions.ReadTimeout as e:
+            except ReadTimeout as e:
                 logger.warning("A ReadTimeout exception occured during sync.")
                 bad_sync_timeout = min(bad_sync_timeout * 2,
                                        self.bad_sync_timeout_limit)


### PR DESCRIPTION
* Adding a request timeout in method `_send` in `api.py`
  * timeout is `10 + query_params.get("timeout", 30000) / 1000` -> OK? IMHO it shouldn't be constant, since it has to be larger than a possible server side timeout
* Handle possible exceptions in `listen_forever`

This should solve #129 and #131 