### PR TITLE
Make level of caching by MatrixClient user-tunable

### DIFF
--- a/test/client_test.py
+++ b/test/client_test.py
@@ -398,7 +398,7 @@ def test_cache():
     responses.add(responses.GET, sync_url, json.dumps(sync_response))
     m1._sync()
 
-    assert m_1.rooms[room_id].name == None
+    assert m_1.rooms[room_id].name is None
     assert m0.rooms[room_id].name == room_name
     assert m1.rooms[room_id].name == room_name
 


### PR DESCRIPTION
This allows lightweight bots to run without all the overhead of keeping track of room state.

Closes #154