### PR TITLE
Fixed redact_event function call in room.py and fixed arguments.

### DIFF
--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -241,13 +241,13 @@ class MatrixHttpApi(object):
             params["ts"] = timestamp
         return self._send("PUT", path, content, query_params=params)
 
-    def redact_event(self, room_id, event_id, reason, txn_id=None, timestamp=None):
+    def redact_event(self, room_id, event_id, content, txn_id=None, timestamp=None):
         """Perferm PUT /rooms/$room_id/redact/$event_id/$txn_id/
 
         Args:
             room_id(str): The room ID to redact the message event in.
             event_id(str): The event id to redact.
-            reason(str): The reason the message was redacted.
+            content(dict): The JSON content to send.
             txn_id(int): Optional. The transaction ID to use.
             timestamp(int): Optional. Set origin_server_ts (For application services only)
         """
@@ -261,7 +261,7 @@ class MatrixHttpApi(object):
         params = {}
         if timestamp:
             params["ts"] = timestamp
-        return self._send("PUT", path, {"reason": reason}, query_params=params)
+        return self._send("PUT", path, content, query_params=params)
 
     # content_type can be a image,audio or video
     # extra information should be supplied, see

--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -247,7 +247,7 @@ class MatrixHttpApi(object):
         Args:
             room_id(str): The room ID to redact the message event in.
             event_id(str): The event id to redact.
-            reason (str): Optional. The JSON content to send.
+            reason (str): Optional. The reason the message was redacted.
             txn_id(int): Optional. The transaction ID to use.
             timestamp(int): Optional. Set origin_server_ts (For application services only)
         """
@@ -264,7 +264,7 @@ class MatrixHttpApi(object):
         params = {}
         if timestamp:
             params["ts"] = timestamp
-        return self._send("PUT", path, content=content, query_params=params)
+        return self._send("PUT", path, content, query_params=params)
 
     # content_type can be a image,audio or video
     # extra information should be supplied, see

--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -241,13 +241,13 @@ class MatrixHttpApi(object):
             params["ts"] = timestamp
         return self._send("PUT", path, content, query_params=params)
 
-    def redact_event(self, room_id, event_id, content, txn_id=None, timestamp=None):
-        """Perferm PUT /rooms/$room_id/redact/$event_id/$txn_id/
+    def redact_event(self, room_id, event_id, reason=None, txn_id=None, timestamp=None):
+        """Perform PUT /rooms/$room_id/redact/$event_id/$txn_id/
 
         Args:
             room_id(str): The room ID to redact the message event in.
             event_id(str): The event id to redact.
-            content(dict): The JSON content to send.
+            reason (str): Optional. The JSON content to send.
             txn_id(int): Optional. The transaction ID to use.
             timestamp(int): Optional. Set origin_server_ts (For application services only)
         """
@@ -258,10 +258,13 @@ class MatrixHttpApi(object):
         path = '/rooms/%s/redact/%s/%s' % (
             room_id, event_id, txn_id
         )
+        content = {}
+        if reason:
+            content['reason'] = reason
         params = {}
         if timestamp:
             params["ts"] = timestamp
-        return self._send("PUT", path, content, query_params=params)
+        return self._send("PUT", path, content=content, query_params=params)
 
     # content_type can be a image,audio or video
     # extra information should be supplied, see

--- a/matrix_client/room.py
+++ b/matrix_client/room.py
@@ -232,7 +232,7 @@ class Room(object):
         if reason:
             content['reason'] = reason
         return self.client.api.redact_event(self.room_id, event_id,
-                                                 content)
+                                            content)
 
     def add_listener(self, callback, event_type=None):
         """ Add a callback handler for events going to this room.

--- a/matrix_client/room.py
+++ b/matrix_client/room.py
@@ -228,8 +228,7 @@ class Room(object):
             event_id (str): The id of the event to be redacted.
             reason (str): Optional. The reason provided for the redaction.
         """
-        return self.client.api.redact_event(self.room_id, event_id,
-                                            reason=reason)
+        return self.client.api.redact_event(self.room_id, event_id, reason)
 
     def add_listener(self, callback, event_type=None):
         """ Add a callback handler for events going to this room.

--- a/matrix_client/room.py
+++ b/matrix_client/room.py
@@ -231,7 +231,7 @@ class Room(object):
         content = {}
         if reason:
             content['reason'] = reason
-        return self.client.api.send_redact_event(self.room_id, event_id,
+        return self.client.api.redact_event(self.room_id, event_id,
                                                  content)
 
     def add_listener(self, callback, event_type=None):

--- a/matrix_client/room.py
+++ b/matrix_client/room.py
@@ -228,11 +228,8 @@ class Room(object):
             event_id (str): The id of the event to be redacted.
             reason (str): Optional. The reason provided for the redaction.
         """
-        content = {}
-        if reason:
-            content['reason'] = reason
         return self.client.api.redact_event(self.room_id, event_id,
-                                            content)
+                                            reason=reason)
 
     def add_listener(self, callback, event_type=None):
         """ Add a callback handler for events going to this room.


### PR DESCRIPTION
This PR is to fix redact_message in room.py calling the incorrect function name for redact_event.

I also made it so redact_event takes a content dict instead of a reason string, because redact_message was already passing a content dict.

Signed-off-by: Ryan Rigby <ryan.rigby@griffithuni.edu.au>