### PR TITLE
Fix documentation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,8 +9,13 @@ Welcome to Matrix Python SDK's documentation!
 Contents:
 
 .. toctree::
+   :glob:
    :maxdepth: 2
 
+   matrix_client
+
+.. include matrix_client.rst
+.. include modules.rst
 
 
 Indices and tables


### PR DESCRIPTION
The documentation used to generate empty documents. Now it pulls the
things from matrix_client.

Signed-off-by: Olivier van der Toorn <oliviervdtoorn@gmail.com>