### PR TITLE
make timeout always an integer

### DIFF
--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -75,7 +75,7 @@ class MatrixHttpApi(object):
         """
 
         request = {
-            "timeout": timeout_ms
+            "timeout": int(timeout_ms)
         }
 
         if since:


### PR DESCRIPTION
non-integer timeouts appear to cause issues.

Signed Off by Stuart Mumford <stuart@cadair.com>