### PR TITLE
always return from _send even if it's irrelevant

### DIFF
--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -673,7 +673,7 @@ class MatrixHttpApi(object):
 
     def set_display_name(self, user_id, display_name):
         content = {"displayname": display_name}
-        self._send("PUT", "/profile/%s/displayname" % user_id, content)
+        return self._send("PUT", "/profile/%s/displayname" % user_id, content)
 
     def get_avatar_url(self, user_id):
         content = self._send("GET", "/profile/%s/avatar_url" % user_id)
@@ -681,7 +681,7 @@ class MatrixHttpApi(object):
 
     def set_avatar_url(self, user_id, avatar_url):
         content = {"avatar_url": avatar_url}
-        self._send("PUT", "/profile/%s/avatar_url" % user_id, content)
+        return self._send("PUT", "/profile/%s/avatar_url" % user_id, content)
 
     def get_download_url(self, mxcurl):
         if mxcurl.startswith('mxc://'):


### PR DESCRIPTION
I have a asyncio subclass of the API that relies of getting the return value of `_send` so this always returns from send.

signed off by Stuart Mumford stuart@cadair.com
  