### PR TITLE
Fix unconditional crash on MatrixRequestError <500

### DIFF
--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -435,8 +435,10 @@ class MatrixClient(object):
                     sleep(bad_sync_timeout)
                     bad_sync_timeout = min(bad_sync_timeout * 2,
                                            self.bad_sync_timeout_limit)
+                elif exception_handler is not None:
+                    exception_handler(e)
                 else:
-                    raise e
+                    raise
             except Exception as e:
                 logger.exception("Exception thrown during sync")
                 if exception_handler is not None:


### PR DESCRIPTION
If a HTTP error with a code < 500 is received, don't just re-raise the
exception, crashing the listener thread, but pass it to exception_handler if
provided.

Fixes #182: HTTP error <500 during sync crashes listener thread