### PR TITLE
Use requests Session instead of ad hoc requests

### DIFF
--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import json
-import requests
+from requests import Session, RequestException
 from time import time, sleep
 from .errors import MatrixError, MatrixRequestError, MatrixHttpLibError
 
@@ -50,6 +50,7 @@ class MatrixHttpApi(object):
         self.identity = identity
         self.txn_id = 0
         self.validate_cert = True
+        self.session = Session()
 
     def initial_sync(self, limit=1):
         """
@@ -645,17 +646,16 @@ class MatrixHttpApi(object):
         if headers["Content-Type"] == "application/json" and content is not None:
             content = json.dumps(content)
 
-        response = None
         while True:
             try:
-                response = requests.request(
+                response = self.session.request(
                     method, endpoint,
                     params=query_params,
                     data=content,
                     headers=headers,
                     verify=self.validate_cert
                 )
-            except requests.exceptions.RequestException as e:
+            except RequestException as e:
                 raise MatrixHttpLibError(e, method, endpoint)
 
             if response.status_code == 429:


### PR DESCRIPTION
This PR introduces a per `MatrixHttpApi` instance requests [`Session`](http://docs.python-requests.org/en/master/user/advanced/#session-objects) which is then used to perform the API HTTP calls instead of the previous ad-hoc `requests.request()` calls.

This enables a few desirable properties:

- Connection pooling / HTTP keep-alive
- Automatic transparent cookie support (useful for some load balancer setups)
- Easy request customization through [`TransportAdapters`](http://docs.python-requests.org/en/master/user/advanced/#transport-adapters) (e.g for custom auth schemes etc.)