### PR TITLE
Add http 429 error handling

### DIFF
--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -36,7 +36,11 @@ class MatrixHttpApi(object):
         base_url (str): The home server URL e.g. 'http://localhost:8008'
         token (str): Optional. The client's access token.
         identity (str): Optional. The mxid to act as (For application services only).
-        default_429_wait_ms (int): Optional. Time in millseconds to wait before retrying a request when in the last attempt the server returned a HTTP 429 response without a 'retry_after_ms' argument. Default to 5000ms
+        default_429_wait_ms (int): Optional. Time in millseconds to wait before retrying
+                                             a request when in the last attempt
+                                             the server returned a HTTP 429 response
+                                             without a 'retry_after_ms' argument.
+                                             Default to 5000ms
 
     Examples:
         Create a client and send a message::

--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -665,13 +665,13 @@ class MatrixHttpApi(object):
 
             if response.status_code == 429:
                 try:
-                    waittime=response.json()['retry_after_ms'] / 1000
+                    waittime = response.json()['retry_after_ms'] / 1000
                 except KeyError:
                     try:
-                        errordata=json.loads(response.json()['error'])
-                        waittime=errordata['retry_after_ms'] / 1000
+                        errordata = json.loads(response.json()['error'])
+                        waittime = errordata['retry_after_ms'] / 1000
                     except KeyError:
-                        waittime=self.default_429_wait_ms / 1000
+                        waittime = self.default_429_wait_ms / 1000
                 finally:
                     sleep(waittime)
             else:

--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -45,14 +45,14 @@ class MatrixHttpApi(object):
             response = matrix.send_message("!roomid:matrix.org", "Hello!")
     """
 
-    def __init__(self, base_url, token=None, identity=None):
+    def __init__(self, base_url, token=None, identity=None, default_429_wait_ms=5000):
         self.base_url = base_url
         self.token = token
         self.identity = identity
         self.txn_id = 0
         self.validate_cert = True
         self.session = Session()
-        self.default_429_wait_ms = 5000
+        self.default_429_wait_ms = default_429_wait_ms
 
     def initial_sync(self, limit=1):
         """

--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -36,6 +36,7 @@ class MatrixHttpApi(object):
         base_url (str): The home server URL e.g. 'http://localhost:8008'
         token (str): Optional. The client's access token.
         identity (str): Optional. The mxid to act as (For application services only).
+        default_429_wait_ms (int): Optional. Time in millseconds to wait before retrying a request when in the last attempt the server returned a HTTP 429 response without a 'retry_after_ms' argument. Default to 5000ms
 
     Examples:
         Create a client and send a message::


### PR DESCRIPTION
This pull request included an error handling process while handling HTTP 429 TOO MANY REQUESTS error.

Here's a sample of matrix.org's HTTP 429 reply:

> {'errcode':'M_UNKNOWN', 'error': '{"errcode":"M_LIMIT_EXCEEDED","error":"Too Many Requests","retry_after_ms":3438}'}

Which would cause an uncaught KeyError in the original implementation.
Also, in order to deal with other non-standard 429 replies, I added a default_429_wait_ms=5000 attribute to be used as a default waiting time if the server didn't provide one.

Signed-off-by: Andy Fu <webmaster@andycloud.dynu.net>