### PR TITLE
Deprecate getters/setters and annotate client.py with TODO project plans

### DIFF
--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -19,6 +19,7 @@ from .user import User
 from threading import Thread
 from time import sleep
 from uuid import uuid4
+from warnings import warn
 import logging
 import sys
 
@@ -81,9 +82,8 @@ class MatrixClient(object):
 
             client = MatrixClient("https://matrix.org", token="foobar",
                 user_id="@foobar:matrix.org")
-            rooms = client.get_rooms()  # NB: From initial sync
             client.add_listener(func)  # NB: event stream callback
-            rooms[0].add_listener(func)  # NB: callbacks just for this room.
+            client.rooms[0].add_listener(func)  # NB: callbacks just for this room.
             room = client.join_room("#matrix:matrix.org")
             response = room.send_text("Hello!")
             response = room.kick("@bob:matrix.org")
@@ -158,12 +158,18 @@ class MatrixClient(object):
             self._sync()
 
     def get_sync_token(self):
+        warn("get_sync_token is deprecated. Directly access MatrixClient.sync_token.",
+             DeprecationWarning)
         return self.sync_token
 
     def set_sync_token(self, token):
+        warn("set_sync_token is deprecated. Directly access MatrixClient.sync_token.",
+             DeprecationWarning)
         self.sync_token = token
 
     def set_user_id(self, user_id):
+        warn("set_user_id is deprecated. Directly access MatrixClient.user_id.",
+             DeprecationWarning)
         self.user_id = user_id
 
     #TODO: combine register methods into single register method controlled by kwargs
@@ -436,7 +442,7 @@ class MatrixClient(object):
             exception_handler (func(exception)): Optional exception handler
                function which can be used to handle exceptions in the caller
                thread.
-            aad_sync_timeout (int): Base time to wait after an error before
+            bad_sync_timeout (int): Base time to wait after an error before
                 retrying. Will be increased according to exponential backoff.
         """
         _bad_sync_timeout = bad_sync_timeout

--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -40,10 +40,11 @@ class Enum(object):
 class Cache(Enum):
     def __init__(self):
         Enum.__init__(self, NONE=-1, SOME=0, ALL=1)
-# TODO: rather than having Cache.NONE as kwarg to MatrixClient, there should be a separate
+
+
+# TODO: rather than having CACHE.NONE as kwarg to MatrixClient, there should be a separate
 # LightweightMatrixClient that only implements global listeners and doesn't hook into
 # User, Room, etc. classes at all.
-
 CACHE = Cache()
 
 
@@ -172,7 +173,7 @@ class MatrixClient(object):
              DeprecationWarning)
         self.user_id = user_id
 
-    #TODO: combine register methods into single register method controlled by kwargs
+    # TODO: combine register methods into single register method controlled by kwargs
     def register_as_guest(self):
         """ Register a guest account on this HS.
         Note: HS must have guest registration enabled.
@@ -214,7 +215,7 @@ class MatrixClient(object):
         self._sync()
         return self.token
 
-    #TODO: combine login methods into single method controlled by kwargs
+    # TODO: combine login methods into single method controlled by kwargs
     def login_with_password_no_sync(self, username, password):
         """ Login to the homeserver.
 
@@ -312,8 +313,8 @@ class MatrixClient(object):
              DeprecationWarning)
         return self.rooms
 
-    #TODO: create Listener class and push as much of this logic there as possible
-    #NOTE: listeners related to things in rooms should be attached to Room objects
+    # TODO: create Listener class and push as much of this logic there as possible
+    # NOTE: listeners related to things in rooms should be attached to Room objects
     def add_listener(self, callback, event_type=None):
         """ Add a listener that will send a callback when the client recieves
         an event.
@@ -530,7 +531,7 @@ class MatrixClient(object):
         self.rooms[room_id] = Room(self, room_id)
         return self.rooms[room_id]
 
-    #TODO: this logic belongs in Room class
+    # TODO: this logic belongs in Room class
     def _process_state_event(self, state_event, current_room):
         if "type" not in state_event:
             return  # Ignore event


### PR DESCRIPTION
@Matrixcoffee could you review this for me? It's the start of my attempt to address your general concerns from #192.

Getters/setters are being removed as they're considered poor python style, and there are ways to make normal attribute access behave like a getter/setter if necessary in the future.