### PR TITLE
Handle state events in 'timeline'

### DIFF
--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -501,44 +501,6 @@ class MatrixClient(object):
         self.rooms[room_id] = Room(self, room_id)
         return self.rooms[room_id]
 
-    def _process_state_event(self, state_event, current_room):
-        if "type" not in state_event:
-            return  # Ignore event
-        etype = state_event["type"]
-        econtent = state_event["content"]
-
-        # Don't keep track of room state if caching turned off
-        if self._cache_level >= 0:
-            if etype == "m.room.name":
-                current_room.name = econtent.get("name")
-            elif etype == "m.room.canonical_alias":
-                current_room.canonical_alias = econtent.get("alias")
-            elif etype == "m.room.topic":
-                current_room.topic = econtent.get("topic")
-            elif etype == "m.room.aliases":
-                current_room.aliases = econtent.get("aliases")
-            elif etype == "m.room.join_rules":
-                current_room.invite_only = econtent["join_rule"] == "invite"
-            elif etype == "m.room.guest_access":
-                current_room.guest_access = econtent["guest_access"] == "can_join"
-            elif etype == "m.room.member" and self._cache_level == CACHE.ALL:
-                # tracking room members can be large e.g. #matrix:matrix.org
-                if econtent["membership"] == "join":
-                    current_room._mkmembers(
-                        User(self.api,
-                             state_event["state_key"],
-                             econtent.get("displayname"))
-                    )
-                elif econtent["membership"] in ("leave", "kick", "invite"):
-                    current_room._rmmembers(state_event["state_key"])
-
-        for listener in current_room.state_listeners:
-            if (
-                listener['event_type'] is None or
-                listener['event_type'] == state_event['type']
-            ):
-                listener['callback'](state_event)
-
     def _sync(self, timeout_ms=30000):
         # TODO: Deal with left rooms
         response = self.api.sync(self.sync_token, timeout_ms, filter=self.sync_filter)
@@ -567,7 +529,7 @@ class MatrixClient(object):
 
             for event in sync_room["state"]["events"]:
                 event['room_id'] = room_id
-                self._process_state_event(event, room)
+                room._process_state_event(event)
 
             for event in sync_room["timeline"]["events"]:
                 event['room_id'] = room_id

--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -26,22 +26,13 @@ logger = logging.getLogger(__name__)
 
 
 # Cache constants used when instantiating Matrix Client to specify level of caching
-class Enum(object):
-    def __init__(self, **kwargs):
-        self._values = kwargs.values()
-        for k, v in kwargs.items():
-            setattr(self, k, v)
-
-    def __contains__(self, item):
-        return item in self._values
+class CACHE(int):
+    pass
 
 
-class Cache(Enum):
-    def __init__(self):
-        Enum.__init__(self, NONE=-1, SOME=0, ALL=1)
-
-
-CACHE = Cache()
+CACHE.NONE = CACHE(-1)
+CACHE.SOME = CACHE(0)
+CACHE.ALL = CACHE(1)
 
 
 class MatrixClient(object):
@@ -132,7 +123,7 @@ class MatrixClient(object):
         self.invite_listeners = []
         self.left_listeners = []
         self.ephemeral_listeners = []
-        if cache_level in CACHE:
+        if isinstance(cache_level, CACHE):
             self._cache_level = cache_level
         else:
             self._cache_level = CACHE.ALL

--- a/matrix_client/room.py
+++ b/matrix_client/room.py
@@ -301,11 +301,12 @@ class Room(object):
                 'event_type': event_type
             }
         )
-
     def _put_event(self, event):
         self.events.append(event)
         if len(self.events) > self.event_history_limit:
             self.events.pop(0)
+        if 'state_key' in event:
+            self._process_state_event(event)
 
         # Dispatch for room-specific listeners
         for listener in self.listeners:

--- a/matrix_client/room.py
+++ b/matrix_client/room.py
@@ -661,6 +661,45 @@ class Room(object):
         except MatrixRequestError:
             return False
 
+    def _process_state_event(self, state_event):
+        if "type" not in state_event:
+            return  # Ignore event
+        etype = state_event["type"]
+        econtent = state_event["content"]
+        clevel = self.client._cache_level
+
+        # Don't keep track of room state if caching turned off
+        if clevel >= 0:
+            if etype == "m.room.name":
+                self.name = econtent.get("name")
+            elif etype == "m.room.canonical_alias":
+                self.canonical_alias = econtent.get("alias")
+            elif etype == "m.room.topic":
+                self.topic = econtent.get("topic")
+            elif etype == "m.room.aliases":
+                self.aliases = econtent.get("aliases")
+            elif etype == "m.room.join_rules":
+                self.invite_only = econtent["join_rule"] == "invite"
+            elif etype == "m.room.guest_access":
+                self.guest_access = econtent["guest_access"] == "can_join"
+            elif etype == "m.room.member" and clevel == clevel.ALL:
+                # tracking room members can be large e.g. #matrix:matrix.org
+                if econtent["membership"] == "join":
+                    self._mkmembers(
+                        User(self.client.api,
+                             state_event["state_key"],
+                             econtent.get("displayname"))
+                    )
+                elif econtent["membership"] in ("leave", "kick", "invite"):
+                    self._rmmembers(state_event["state_key"])
+
+        for listener in self.state_listeners:
+            if (
+                listener['event_type'] is None or
+                listener['event_type'] == state_event['type']
+            ):
+                listener['callback'](state_event)
+
     @property
     def prev_batch(self):
         return self._prev_batch

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -64,7 +64,7 @@ def test_bad_state_events():
         "tomato": False
     }
 
-    client._process_state_event(ev, room)
+    room._process_state_event(ev)
 
 
 def test_state_event():
@@ -80,54 +80,54 @@ def test_state_event():
         "content": {}
     }
 
-    client._process_state_event(ev, room)
+    room._process_state_event(ev)
     assert room.name is None
 
     ev["content"]["name"] = "TestName"
-    client._process_state_event(ev, room)
+    room._process_state_event(ev)
     assert room.name is "TestName"
 
     ev["type"] = "m.room.topic"
-    client._process_state_event(ev, room)
+    room._process_state_event(ev)
     assert room.topic is None
 
     ev["content"]["topic"] = "TestTopic"
-    client._process_state_event(ev, room)
+    room._process_state_event(ev)
     assert room.topic is "TestTopic"
 
     ev["type"] = "m.room.aliases"
-    client._process_state_event(ev, room)
+    room._process_state_event(ev)
     assert room.aliases is None
 
     aliases = ["#foo:matrix.org", "#bar:matrix.org"]
     ev["content"]["aliases"] = aliases
-    client._process_state_event(ev, room)
+    room._process_state_event(ev)
     assert room.aliases is aliases
 
     # test member join event
     ev["type"] = "m.room.member"
     ev["content"] = {'membership': 'join', 'displayname': 'stereo'}
     ev["state_key"] = "@stereo:xxx.org"
-    client._process_state_event(ev, room)
+    room._process_state_event(ev)
     assert len(room._members) == 1
     assert room._members[0].user_id == "@stereo:xxx.org"
     # test member leave event
     ev["content"]['membership'] = 'leave'
-    client._process_state_event(ev, room)
+    room._process_state_event(ev)
     assert len(room._members) == 0
 
     # test join_rules
     room.invite_only = False
     ev["type"] = "m.room.join_rules"
     ev["content"] = {"join_rule": "invite"}
-    client._process_state_event(ev, room)
+    room._process_state_event(ev)
     assert room.invite_only
 
     # test guest_access
     room.guest_access = False
     ev["type"] = "m.room.guest_access"
     ev["content"] = {"guest_access": "can_join"}
-    client._process_state_event(ev, room)
+    room._process_state_event(ev)
     assert room.guest_access
 
 

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -418,7 +418,7 @@ def test_cache():
     assert m_all.rooms[room_id].name == room_name
 
     assert m_none.rooms[room_id]._members == m_some.rooms[room_id]._members == []
-    assert len(m_all.rooms[room_id]._members) == 1
+    assert len(m_all.rooms[room_id]._members) == 2
     assert m_all.rooms[room_id]._members[0].user_id == "@alice:example.com"
 
 


### PR DESCRIPTION
Fixes #195

Although the actual fix ended up being only 2 simple extra lines, there's quite some pre-work.

Had to refactor the Enum replacement so I could refer to its constants in the room module, and managed to make it simpler using only 5 SLOC.

Moved `_process_state_event` to the room class as well, which really benefited the next patch needing only 2 SLOC.

Suggest a non-squashing merge for this PR.

Tests were fixed blindly. LMK if they broke.