### PR TITLE
Add check to get_avatar_url()

### DIFF
--- a/matrix_client/user.py
+++ b/matrix_client/user.py
@@ -38,7 +38,9 @@ class User(object):
 
     def get_avatar_url(self):
         mxcurl = self.api.get_avatar_url(self.user_id)
-        url = self.api.get_download_url(mxcurl)
+        url = None
+        if mxcurl is not None:
+            url = self.api.get_download_url(mxcurl)
         return url
 
     def set_avatar_url(self, avatar_url):


### PR DESCRIPTION
This PR adds a check to `get_avatar_url()` in `user.py` to see if the avatar actually exists before calling the `get_download_url()` method.

Signed-off-by: Dylan Van Assche <dylan.van.assche@protonmail.com>

Fixed #200 