### PR TITLE
fix full_state sync parameter

### DIFF
--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -96,7 +96,7 @@ class MatrixHttpApi(object):
             request["filter"] = filter
 
         if full_state:
-            request["full_state"] = full_state
+            request["full_state"] = json.dumps(full_state)
 
         if set_presence:
             request["set_presence"] = set_presence


### PR DESCRIPTION
Otherwise the url parameter is "full_state=True" instead of  "full_state=true" and Synapse returns an error.

Signed-off-by: Valentin Deniaud \<valentin.deniaud@inpt.fr\>