### PR TITLE
do not return the internal list of joined members

### DIFF
--- a/matrix_client/room.py
+++ b/matrix_client/room.py
@@ -84,8 +84,8 @@ class Room(object):
 
         members = self.get_joined_members()
         # members without me
-        members[:] = [u.get_display_name() for u in members if
-                      self.client.user_id != u.user_id]
+        members = [u.get_display_name() for u in members if
+                   self.client.user_id != u.user_id]
         first_two = members[:2]
         if len(first_two) == 1:
             return first_two[0]


### PR DESCRIPTION
I found a nice bug here https://github.com/matrix-org/matrix-python-sdk/blob/master/matrix_client/room.py#L87. It causes the _members list of User object to be overwritten, resulting in _members being a list of strings (the display names of the Users).

Obviously there are a lot of different way to fix this, I believe this one is the best but I'm open to suggestions.

Signed-off-by: Valentin Deniaud \<valentin.deniaud@inpt.fr\>