### PR TITLE
[E2E] Plug-in encryption in client

### DIFF
--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -59,6 +59,8 @@ class MatrixClient(object):
             the token) if supplying a token; otherwise, ignored.
         valid_cert_check (bool): Check the homeservers
             certificate on connections?
+        cache_level (CACHE): One of CACHE.NONE, CACHE.SOME, or
+            CACHE.ALL (defined in module namespace).
         encryption (bool): Optional. Whether or not to enable end-to-end encryption
             support.
         encryption_conf (dict): Optional. Configuration parameters for encryption.
@@ -106,27 +108,6 @@ class MatrixClient(object):
     def __init__(self, base_url, token=None, user_id=None,
                  valid_cert_check=True, sync_filter_limit=20,
                  cache_level=CACHE.ALL, encryption=False, encryption_conf=None):
-        """ Create a new Matrix Client object.
-
-        Args:
-            base_url (str): The url of the HS preceding /_matrix.
-                e.g. (ex: https://localhost:8008 )
-            token (str): Optional. If you have an access token
-                supply it here.
-            user_id (str): Optional. You must supply the user_id
-                (as obtained when initially logging in to obtain
-                the token) if supplying a token; otherwise, ignored.
-            valid_cert_check (bool): Check the homeservers
-                certificate on connections?
-            cache_level (CACHE): One of CACHE.NONE, CACHE.SOME, or
-                CACHE.ALL (defined in module namespace).
-
-        Returns:
-            MatrixClient
-
-        Raises:
-            MatrixRequestError, ValueError
-        """
         if token is not None and user_id is None:
             raise ValueError("must supply user_id along with token")
         if encryption and not ENCRYPTION_SUPPORT:

--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -59,6 +59,11 @@ class MatrixClient(object):
             the token) if supplying a token; otherwise, ignored.
         valid_cert_check (bool): Check the homeservers
             certificate on connections?
+        encryption (bool): Optional. Whether or not to enable end-to-end encryption
+            support.
+        encryption_conf (dict): Optional. Configuration parameters for encryption.
+            Refer to :func:`~matrix_client.crypto.olm_device.OlmDevice` for supported
+            options, since it will be passed to this class.
 
     Returns:
         `MatrixClient`
@@ -100,7 +105,7 @@ class MatrixClient(object):
 
     def __init__(self, base_url, token=None, user_id=None,
                  valid_cert_check=True, sync_filter_limit=20,
-                 cache_level=CACHE.ALL, encryption=False):
+                 cache_level=CACHE.ALL, encryption=False, encryption_conf=None):
         """ Create a new Matrix Client object.
 
         Args:
@@ -137,6 +142,7 @@ class MatrixClient(object):
         self.ephemeral_listeners = []
         self.device_id = None
         self._encryption = encryption
+        self.encryption_conf = encryption_conf or {}
         self.olm_device = None
         if isinstance(cache_level, CACHE):
             self._cache_level = cache_level
@@ -288,7 +294,7 @@ class MatrixClient(object):
 
         if self._encryption:
             self.olm_device = OlmDevice(
-                self.api, self.user_id, self.device_id)
+                self.api, self.user_id, self.device_id, **self.encryption_conf)
             self.olm_device.upload_identity_keys()
             self.olm_device.upload_one_time_keys()
 

--- a/matrix_client/crypto/olm_device.py
+++ b/matrix_client/crypto/olm_device.py
@@ -4,6 +4,7 @@ import olm
 from canonicaljson import encode_canonical_json
 
 from matrix_client.checks import check_user_id
+from matrix_client.crypto.one_time_keys import OneTimeKeysManager
 
 logger = logging.getLogger(__name__)
 
@@ -17,13 +18,21 @@ class OlmDevice(object):
         api (MatrixHttpApi): The api object used to make requests.
         user_id (str): Matrix user ID. Must match the one used when logging in.
         device_id (str): Must match the one used when logging in.
+        signed_keys_proportion (float): Optional. The proportion of signed one-time keys
+            we should maintain on the HS compared to unsigned keys. The maximum value of
+            ``1`` means only signed keys will be uploaded, while the minimum value of
+            ``0`` means only unsigned keys. The actual amount of keys is determined at
+            runtime from the given proportion and the maximum number of one-time keys
+            we can physically hold.
     """
 
     _olm_algorithm = 'm.olm.v1.curve25519-aes-sha2'
     _megolm_algorithm = 'm.megolm.v1.aes-sha2'
     _algorithms = [_olm_algorithm, _megolm_algorithm]
 
-    def __init__(self, api, user_id, device_id):
+    def __init__(self, api, user_id, device_id, signed_keys_proportion=1):
+        if not 0 <= signed_keys_proportion <= 1:
+            raise ValueError('signed_keys_proportion must be between 0 and 1.')
         self.api = api
         check_user_id(user_id)
         self.user_id = user_id
@@ -31,7 +40,13 @@ class OlmDevice(object):
         self.olm_account = olm.Account()
         logger.info('Initialised Olm Device.')
         self.identity_keys = self.olm_account.identity_keys
-        self.one_time_key_counts = {}
+        # Try to maintain half the number of one-time keys libolm can hold uploaded
+        # on the HS. This is because some keys will be claimed by peers but not
+        # used instantly, and we want them to stay in libolm, until the limit is reached
+        # and it starts discarding keys, starting by the oldest.
+        target_keys_number = self.olm_account.max_one_time_keys // 2
+        self.one_time_keys_manager = OneTimeKeysManager(target_keys_number,
+                                                        signed_keys_proportion)
 
     def upload_identity_keys(self):
         """Uploads this device's identity keys to HS.
@@ -47,8 +62,56 @@ class OlmDevice(object):
         }
         self.sign_json(device_keys)
         ret = self.api.upload_keys(device_keys=device_keys)
-        self.one_time_key_counts = ret['one_time_key_counts']
+        self.one_time_keys_manager.server_counts = ret['one_time_key_counts']
         logger.info('Uploaded identity keys.')
+
+    def upload_one_time_keys(self, force_update=False):
+        """Uploads new one-time keys to the HS, if needed.
+
+        Args:
+            force_update (bool): Fetch the number of one-time keys currently on the HS
+                before uploading, even if we already know one. In most cases this should
+                not be necessary, as we get this value from sync responses.
+
+        Returns:
+            A dict containg the number of new keys that were uploaded for each key type
+                (signed_curve25519 or curve25519). The format is
+                ``<key_type>: <uploaded_number>``. If no keys of a given type have been
+                uploaded, the corresponding key will not be present. Consequently, an
+                empty dict indicates that no keys were uploaded.
+        """
+        if force_update or not self.one_time_keys_manager.server_counts:
+            counts = self.api.upload_keys()['one_time_key_counts']
+            self.one_time_keys_manager.server_counts = counts
+
+        signed_keys_to_upload = self.one_time_keys_manager.signed_curve25519_to_upload
+        unsigned_keys_to_upload = self.one_time_keys_manager.curve25519_to_upload
+
+        self.olm_account.generate_one_time_keys(signed_keys_to_upload +
+                                                unsigned_keys_to_upload)
+
+        one_time_keys = {}
+        keys = self.olm_account.one_time_keys['curve25519']
+        for i, key_id in enumerate(keys):
+            if i < signed_keys_to_upload:
+                key = self.sign_json({'key': keys[key_id]})
+                key_type = 'signed_curve25519'
+            else:
+                key = keys[key_id]
+                key_type = 'curve25519'
+            one_time_keys['{}:{}'.format(key_type, key_id)] = key
+
+        ret = self.api.upload_keys(one_time_keys=one_time_keys)
+        self.one_time_keys_manager.server_counts = ret['one_time_key_counts']
+        self.olm_account.mark_keys_as_published()
+
+        keys_uploaded = {}
+        if unsigned_keys_to_upload:
+            keys_uploaded['curve25519'] = unsigned_keys_to_upload
+        if signed_keys_to_upload:
+            keys_uploaded['signed_curve25519'] = signed_keys_to_upload
+        logger.info('Uploaded new one-time keys: %s.', keys_uploaded)
+        return keys_uploaded
 
     def sign_json(self, json):
         """Signs a JSON object.

--- a/matrix_client/crypto/one_time_keys.py
+++ b/matrix_client/crypto/one_time_keys.py
@@ -1,0 +1,33 @@
+class OneTimeKeysManager(object):
+    """Handles one-time keys accounting for an OlmDevice."""
+
+    def __init__(self, target_keys_number, signed_keys_proportion):
+        self.target_counts = {
+            'signed_curve25519': int(round(signed_keys_proportion * target_keys_number)),
+            'curve25519': int(round((1 - signed_keys_proportion) * target_keys_number)),
+        }
+        self._server_counts = {}
+        self.to_upload = {}
+
+    @property
+    def server_counts(self):
+        return self._server_counts
+
+    @server_counts.setter
+    def server_counts(self, server_counts):
+        self._server_counts = server_counts
+        self.update_keys_to_upload()
+
+    def update_keys_to_upload(self):
+        for key_type, target_number in self.target_counts.items():
+            num_keys = self._server_counts.get(key_type, 0)
+            num_to_create = max(target_number - num_keys, 0)
+            self.to_upload[key_type] = num_to_create
+
+    @property
+    def curve25519_to_upload(self):
+        return self.to_upload.get('curve25519', 0)
+
+    @property
+    def signed_curve25519_to_upload(self):
+        return self.to_upload.get('signed_curve25519', 0)

--- a/matrix_client/room.py
+++ b/matrix_client/room.py
@@ -22,14 +22,13 @@ from .errors import MatrixRequestError
 
 
 class Room(object):
-    """Call room-specific functions after joining a room from the client."""
+    """Call room-specific functions after joining a room from the client.
+
+    NOTE: This should ideally be called from within the Client.
+    NOTE: This does not verify the room with the Home Server.
+    """
 
     def __init__(self, client, room_id):
-        """Create a blank Room object.
-
-            NOTE: This should ideally be called from within the Client.
-            NOTE: This does not verify the room with the Home Server.
-        """
         check_room_id(room_id)
 
         self.room_id = room_id

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -452,3 +452,20 @@ def test_room_guest_access():
 
     assert room.set_guest_access(True)
     assert room.guest_access
+
+
+@responses.activate
+def test_enable_encryption():
+    pytest.importorskip('olm')
+    client = MatrixClient(HOSTNAME, encryption=True)
+
+    login_path = HOSTNAME + MATRIX_V2_API_PATH + "/login"
+    responses.add(responses.POST, login_path,
+                  json=response_examples.example_success_login_response)
+
+    upload_path = HOSTNAME + MATRIX_V2_API_PATH + '/keys/upload'
+    responses.add(responses.POST, upload_path, body='{"one_time_key_counts": {}}')
+
+    client.login("@example:localhost", "password", sync=False)
+
+    assert client.olm_device

--- a/test/response_examples.py
+++ b/test/response_examples.py
@@ -167,3 +167,10 @@ example_key_upload_response = {
         "signed_curve25519": 20
     }
 }
+
+example_success_login_response = {
+    "user_id": "@example:localhost",
+    "access_token": "abc123",
+    "home_server": "matrix.org",
+    "device_id": "GHTYAJCE"
+}

--- a/test/response_examples.py
+++ b/test/response_examples.py
@@ -160,3 +160,10 @@ example_pl_event = {
 example_event_response = {
     "event_id": "YUwRidLecu"
 }
+
+example_key_upload_response = {
+    "one_time_key_counts": {
+        "curve25519": 10,
+        "signed_curve25519": 20
+    }
+}


### PR DESCRIPTION
First attempt at trying to integrate e2e into the existing code. No crypto stuff in this one.

With this PR and the later ones I aim at two things:
  - Introduce no breaking changes, every existing code built upon the SDK should keep working without any noticeable difference.
  - Making it real simple to enable and use e2e. Right now it is as simple as passing `encryption=True` to MatrixClient.

Not sure about the optional dependency handling in this one, that is why I made it a separate commit. If it's the right way to do it, let me know and I'll squash 'em.

Signed-off-by: Valentin Deniaud \<valentin.deniaud@inpt.fr\>