### PR TITLE
[E2E] track one time keys count in sync response

### DIFF
--- a/matrix_client/crypto/one_time_keys.py
+++ b/matrix_client/crypto/one_time_keys.py
@@ -1,13 +1,14 @@
 class OneTimeKeysManager(object):
     """Handles one-time keys accounting for an OlmDevice."""
 
-    def __init__(self, target_keys_number, signed_keys_proportion):
+    def __init__(self, target_keys_number, signed_keys_proportion, keys_threshold):
         self.target_counts = {
             'signed_curve25519': int(round(signed_keys_proportion * target_keys_number)),
             'curve25519': int(round((1 - signed_keys_proportion) * target_keys_number)),
         }
         self._server_counts = {}
         self.to_upload = {}
+        self.keys_threshold = keys_threshold
 
     @property
     def server_counts(self):
@@ -23,6 +24,14 @@ class OneTimeKeysManager(object):
             num_keys = self._server_counts.get(key_type, 0)
             num_to_create = max(target_number - num_keys, 0)
             self.to_upload[key_type] = num_to_create
+
+    def should_upload(self):
+        if not self._server_counts:
+            return True
+        for key_type, target_number in self.target_counts.items():
+            if self._server_counts.get(key_type, 0) < target_number * self.keys_threshold:
+                return True
+        return False
 
     @property
     def curve25519_to_upload(self):


### PR DESCRIPTION
This feature is currently undocumented, but quite self-explanatory.  
Here is my try at the missing documentation, not yet reviewed: https://github.com/matrix-org/matrix-doc/pull/1284/commits/fce04f011e29b419b88c1c1487f64f6d6620c557

I wonder if this crosses the red-line "never initiate a new request during /sync/ processing".

Signed-off-by: Valentin Deniaud \<valentin.deniaud@inpt.fr\>