### PR TITLE
[E2E] Persistence

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -96,4 +96,4 @@ texinfo_documents = [
      'Miscellaneous'),
 ]
 
-autodoc_mock_imports = ["olm", "canonicaljson"]
+autodoc_mock_imports = ["olm", "canonicaljson", "appdirs"]

--- a/docs/source/matrix_client.rst
+++ b/docs/source/matrix_client.rst
@@ -56,3 +56,8 @@ matrix_client.crypto
     :members:
     :undoc-members:
     :show-inheritance:
+
+.. automodule:: matrix_client.crypto.device_list
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/matrix_client.rst
+++ b/docs/source/matrix_client.rst
@@ -61,3 +61,8 @@ matrix_client.crypto
     :members:
     :undoc-members:
     :show-inheritance:
+
+.. automodule:: matrix_client.crypto.megolm_outbound_session
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/matrix_client.rst
+++ b/docs/source/matrix_client.rst
@@ -66,3 +66,8 @@ matrix_client.crypto
     :members:
     :undoc-members:
     :show-inheritance:
+
+.. automodule:: matrix_client.crypto.crypto_store
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -343,6 +343,18 @@ class MatrixHttpApi(object):
         return self.send_message_event(room_id, "m.room.message", content_pack,
                                        timestamp=timestamp)
 
+    def get_location_body(self, geo_uri, name, thumb_url=None, thumb_info=None):
+        content_pack = {
+            "geo_uri": geo_uri,
+            "msgtype": "m.location",
+            "body": name,
+        }
+        if thumb_url:
+            content_pack["thumbnail_url"] = thumb_url
+        if thumb_info:
+            content_pack["thumbnail_info"] = thumb_info
+        return content_pack
+
     # http://matrix.org/docs/spec/client_server/r0.2.0.html#m-location
     def send_location(self, room_id, geo_uri, name, thumb_url=None, thumb_info=None,
                       timestamp=None):
@@ -356,15 +368,8 @@ class MatrixHttpApi(object):
             thumb_info (dict): Metadata about the thumbnail, type ImageInfo.
             timestamp (int): Set origin_server_ts (For application services only)
         """
-        content_pack = {
-            "geo_uri": geo_uri,
-            "msgtype": "m.location",
-            "body": name,
-        }
-        if thumb_url:
-            content_pack["thumbnail_url"] = thumb_url
-        if thumb_info:
-            content_pack["thumbnail_info"] = thumb_info
+        content_pack = self.get_location_body(
+            geo_uri, name, thumb_url, thumb_info)
 
         return self.send_message_event(room_id, "m.room.message", content_pack,
                                        timestamp=timestamp)
@@ -405,12 +410,11 @@ class MatrixHttpApi(object):
             text_content (str): The m.notice body to send.
             timestamp (int): Set origin_server_ts (For application services only)
         """
-        body = {
-            "msgtype": "m.notice",
-            "body": text_content
-        }
-        return self.send_message_event(room_id, "m.room.message", body,
-                                       timestamp=timestamp)
+        return self.send_message_event(
+            room_id, "m.room.message",
+            self.get_notice_body(text_content),
+            timestamp=timestamp
+        )
 
     def get_room_messages(self, room_id, token, direction, limit=10, to=None):
         """Perform GET /rooms/{roomId}/messages.
@@ -672,6 +676,12 @@ class MatrixHttpApi(object):
     def get_emote_body(self, text):
         return {
             "msgtype": "m.emote",
+            "body": text
+        }
+
+    def get_notice_body(self, text):
+        return {
+            "msgtype": "m.notice",
             "body": text
         }
 

--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -581,6 +581,15 @@ class MatrixClient(object):
     # TODO better handling of the blocking I/O caused by update_one_time_key_counts
     def _sync(self, timeout_ms=30000):
         response = self.api.sync(self.sync_token, timeout_ms, filter=self.sync_filter)
+
+        if self._encryption and 'device_lists' in response:
+            if response['device_lists'].get('changed'):
+                self.olm_device.device_list.update_user_device_keys(
+                    response['device_lists']['changed'], self.sync_token)
+            if response['device_lists'].get('left'):
+                self.olm_device.device_list.stop_tracking_users(
+                    response['device_lists']['left'])
+
         self.sync_token = response["next_batch"]
 
         for presence_update in response['presence']['events']:

--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -133,6 +133,7 @@ class MatrixClient(object):
         self._encryption = encryption
         self.encryption_conf = encryption_conf or {}
         self.olm_device = None
+        self.first_sync = True
         if isinstance(cache_level, CACHE):
             self._cache_level = cache_level
         else:
@@ -591,6 +592,10 @@ class MatrixClient(object):
                     response['device_lists']['left'])
 
         self.sync_token = response["next_batch"]
+
+        if self._encryption and self.first_sync:
+            self.first_sync = False
+            self.olm_device.device_list.update_after_restart(self.sync_token)
 
         for presence_update in response['presence']['events']:
             for callback in self.presence_listeners.values():

--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -636,6 +636,10 @@ class MatrixClient(object):
                     ):
                         listener['callback'](event)
 
+            if self._encryption and room.encrypted:
+                # Track the new users in the room
+                self.olm_device.device_list.track_pending_users()
+
             for event in sync_room['ephemeral']['events']:
                 event['room_id'] = room_id
                 room._put_ephemeral_event(event)

--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -606,6 +606,11 @@ class MatrixClient(object):
             if room_id in self.rooms:
                 del self.rooms[room_id]
 
+        if 'to_device' in response:
+            for event in response['to_device']['events']:
+                if event['type'] == 'm.room.encrypted' and self._encryption:
+                    self.olm_device.olm_handle_encrypted_event(event)
+
         if self._encryption and 'device_one_time_keys_count' in response:
             self.olm_device.update_one_time_key_counts(
                 response['device_one_time_keys_count'])

--- a/matrix_client/crypto/crypto_store.py
+++ b/matrix_client/crypto/crypto_store.py
@@ -59,6 +59,7 @@ class CryptoStore(object):
         """Ensures all the tables exist."""
         c = self.conn.cursor()
         c.executescript("""
+PRAGMA secure_delete = ON;
 PRAGMA foreign_keys = ON;
 CREATE TABLE IF NOT EXISTS accounts(
     device_id TEXT NOT NULL UNIQUE, account BLOB, user_id TEXT PRIMARY KEY NOT NULL

--- a/matrix_client/crypto/crypto_store.py
+++ b/matrix_client/crypto/crypto_store.py
@@ -1,0 +1,94 @@
+import logging
+import os
+import sqlite3
+
+import olm
+from appdirs import user_data_dir
+
+logger = logging.getLogger(__name__)
+
+
+class CryptoStore(object):
+    """Manages persistent storage for an OlmDevice.
+
+    Args:
+        device_id (str): The device id of the OlmDevice.
+        db_name (str): Optional. The name of the database file to use. Will be created
+            if necessary.
+        db_path (str): Optional. The path where to store the database file. Defaults to
+            the system default application data directory.
+        app_name (str): Optional. The application name, which will be used to determine
+            where the database is located. Ignored if db_path is supplied.
+        pickle_key (str): Optional. A key to encrypt the database contents.
+    """
+
+    def __init__(self,
+                 device_id,
+                 db_name='crypto.db',
+                 db_path=None,
+                 app_name='matrix-python-sdk',
+                 pickle_key='DEFAULT_KEY'):
+        self.device_id = device_id
+        data_dir = db_path or user_data_dir(app_name, '')
+        try:
+            os.makedirs(data_dir)
+        except OSError:
+            pass
+        self.conn = sqlite3.connect(os.path.join(data_dir, db_name))
+        self.pickle_key = pickle_key
+        self.create_tables_if_needed()
+
+    def create_tables_if_needed(self):
+        """Ensures all the tables exist."""
+        c = self.conn.cursor()
+        c.execute('CREATE TABLE IF NOT EXISTS accounts (device_id TEXT PRIMARY KEY,'
+                  'account BLOB)')
+        c.close()
+        self.conn.commit()
+
+    def save_olm_account(self, account):
+        """Saves an Olm account.
+
+        Args:
+            account (olm.Account): The account object to save.
+        """
+        account_data = account.pickle(self.pickle_key)
+        c = self.conn.cursor()
+        c.execute('INSERT OR IGNORE INTO accounts (device_id, account) VALUES (?,?)',
+                  (self.device_id, account_data))
+        c.execute('UPDATE accounts SET account=? WHERE device_id=?',
+                  (account_data, self.device_id))
+        c.close()
+        self.conn.commit()
+
+    def get_olm_account(self):
+        """Gets the Olm account.
+
+        Returns:
+            olm.Account object, or None if it wasn't found for the current device_id.
+        """
+        c = self.conn.cursor()
+        c.execute(
+            'SELECT account FROM accounts WHERE device_id=?', (self.device_id,))
+        try:
+            account_data = c.fetchone()[0]
+            # sqlite gives us unicode in Python2, we want bytes
+            account_data = bytes(account_data)
+        except TypeError:
+            return None
+        finally:
+            c.close()
+        return olm.Account.from_pickle(account_data, self.pickle_key)
+
+    def remove_olm_account(self):
+        """Removes the Olm account.
+
+        NOTE: Doing so will remove any saved information associated with the account
+        (keys, sessions...)
+        """
+        c = self.conn.cursor()
+        c.execute('DELETE FROM accounts WHERE device_id=?', (self.device_id,))
+        c.close()
+
+    def close(self):
+        self.conn.close()

--- a/matrix_client/crypto/crypto_store.py
+++ b/matrix_client/crypto/crypto_store.py
@@ -67,24 +67,25 @@ CREATE TABLE IF NOT EXISTS megolm_inbound_sessions(
     FOREIGN KEY(device_id) REFERENCES accounts(device_id) ON DELETE CASCADE
 );
 CREATE TABLE IF NOT EXISTS megolm_outbound_sessions(
-    device_id TEXT, room_id TEXT PRIMARY KEY, session BLOB, max_age_s FLOAT,
+    device_id TEXT, room_id TEXT, session BLOB, max_age_s FLOAT,
     max_messages INTEGER, creation_time TIMESTAMP, message_count INTEGER,
+    PRIMARY KEY(device_id, room_id),
     FOREIGN KEY(device_id) REFERENCES accounts(device_id) ON DELETE CASCADE
 );
 CREATE TABLE IF NOT EXISTS megolm_outbound_devices(
     device_id TEXT, room_id TEXT, user_device_id TEXT,
-    UNIQUE(device_id, room_id, user_device_id),
-    FOREIGN KEY(room_id) REFERENCES megolm_outbound_sessions(room_id) ON DELETE CASCADE,
-    FOREIGN KEY(device_id) REFERENCES accounts(device_id)
+    PRIMARY KEY(device_id, room_id, user_device_id),
+    FOREIGN KEY(device_id, room_id) REFERENCES
+    megolm_outbound_sessions(device_id, room_id) ON DELETE CASCADE
 );
 CREATE TABLE IF NOT EXISTS device_keys(
-    device_id TEXT, user_id TEXT, user_device_id TEXT PRIMARY KEY, ed_key TEXT,
-    curve_key TEXT,
+    device_id TEXT, user_id TEXT, user_device_id TEXT, ed_key TEXT,
+    curve_key TEXT, PRIMARY KEY(device_id, user_id, user_device_id),
     FOREIGN KEY(device_id) REFERENCES accounts(device_id) ON DELETE CASCADE
 );
 CREATE TABLE IF NOT EXISTS tracked_users(
     device_id TEXT, user_id TEXT,
-    UNIQUE(device_id, user_id),
+    PRIMARY KEY(device_id, user_id),
     FOREIGN KEY(device_id) REFERENCES accounts(device_id) ON DELETE CASCADE
 );
 CREATE TABLE IF NOT EXISTS sync_tokens(

--- a/matrix_client/crypto/crypto_store.py
+++ b/matrix_client/crypto/crypto_store.py
@@ -1,9 +1,12 @@
 import logging
 import os
 import sqlite3
+from datetime import timedelta
 
 import olm
 from appdirs import user_data_dir
+
+from matrix_client.crypto.megolm_outbound_session import MegolmOutboundSession
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +37,8 @@ class CryptoStore(object):
             os.makedirs(data_dir)
         except OSError:
             pass
-        self.conn = sqlite3.connect(os.path.join(data_dir, db_name))
+        self.conn = sqlite3.connect(os.path.join(data_dir, db_name),
+                                    detect_types=sqlite3.PARSE_DECLTYPES)
         self.pickle_key = pickle_key
         self.create_tables_if_needed()
 
@@ -53,6 +57,18 @@ class CryptoStore(object):
                   'curve_key TEXT, session BLOB,'
                   'FOREIGN KEY(device_id) REFERENCES accounts(device_id) '
                   'ON DELETE CASCADE)')
+        c.execute('CREATE TABLE IF NOT EXISTS megolm_outbound_sessions '
+                  '(device_id TEXT, room_id TEXT PRIMARY KEY, session BLOB,'
+                  'max_age_s FLOAT, max_messages INTEGER, creation_time TIMESTAMP,'
+                  'message_count INTEGER,'
+                  'FOREIGN KEY(device_id) REFERENCES accounts(device_id) '
+                  'ON DELETE CASCADE)')
+        c.execute('CREATE TABLE IF NOT EXISTS megolm_outbound_devices '
+                  '(device_id TEXT, room_id TEXT, user_device_id TEXT,'
+                  'UNIQUE(device_id, room_id, user_device_id),'
+                  'FOREIGN KEY(room_id) REFERENCES megolm_outbound_sessions(room_id) '
+                  'ON DELETE CASCADE,'
+                  'FOREIGN KEY(device_id) REFERENCES accounts(device_id))')
         c.close()
         self.conn.commit()
 
@@ -224,6 +240,120 @@ class CryptoStore(object):
         if sessions is not None:
             sessions[session.id] = session
         return session
+
+    def save_outbound_session(self, room_id, session):
+        """Saves a Megolm outbound session.
+
+        Args:
+            room_id (str): The room corresponding to the session.
+            session (MegolmOutboundSession): The session to save.
+        """
+        c = self.conn.cursor()
+        pickle = session.pickle(self.pickle_key)
+        c.execute(
+            'INSERT OR IGNORE INTO megolm_outbound_sessions VALUES (?,?,?,?,?,?,?)',
+            (self.device_id, room_id, pickle, session.max_age.total_seconds(),
+             session.max_messages, session.creation_time, session.message_count)
+        )
+        c.execute('UPDATE megolm_outbound_sessions SET session=? WHERE device_id=? AND '
+                  'room_id=?', (pickle, self.device_id, room_id))
+        c.close()
+        self.conn.commit()
+
+    def load_outbound_sessions(self, sessions):
+        """Loads all saved outbound Megolm sessions.
+
+        Also loads the devices each are shared with.
+
+        Args:
+            sessions (dict): A map from room_id to a :class:`.MegolmOutboundSession`
+                object, which will be populated.
+        """
+        c = self.conn.cursor()
+        rows = c.execute(
+            'SELECT room_id, session, max_age_s, max_messages, creation_time,'
+            'message_count FROM megolm_outbound_sessions WHERE device_id=?',
+            (self.device_id,)
+        )
+        for row in rows.fetchall():
+            device_ids = c.execute(
+                'SELECT user_device_id FROM megolm_outbound_devices WHERE device_id=? '
+                'AND room_id=?', (self.device_id, row[0])
+            )
+            devices = {device_id[0] for device_id in device_ids}
+            max_age_s = row[2]
+            max_age = timedelta(seconds=max_age_s)
+            session = MegolmOutboundSession.from_pickle(
+                bytes(row[1]), devices, max_age, row[3], row[4], row[5], self.pickle_key)
+            sessions[row[0]] = session
+        c.close()
+
+    def get_outbound_session(self, room_id, sessions=None):
+        """Gets a saved outbound Megolm session.
+
+        Also loads the devices it is shared with.
+
+        Args:
+            room_id (str): The room corresponding to the session.
+            sessions (dict): Optional. A map from room_id to a
+                :class:`.MegolmOutboundSession` object, to which the session will be
+                added.
+
+        Returns:
+            :class:`.MegolmOutboundSession` object, or ``None`` if the session was
+            not found.
+        """
+        c = self.conn.cursor()
+        c.execute(
+            'SELECT session, max_age_s, max_messages, creation_time, message_count '
+            'FROM megolm_outbound_sessions WHERE device_id=? AND room_id=?',
+            (self.device_id, room_id)
+        )
+        try:
+            row = c.fetchone()
+            session_data = bytes(row[0])
+        except TypeError:
+            c.close()
+            return None
+        device_ids = c.execute(
+            'SELECT user_device_id FROM megolm_outbound_devices WHERE device_id=? '
+            'AND room_id=?', (self.device_id, room_id)
+        )
+        devices = {device_id[0] for device_id in device_ids}
+        c.close()
+        max_age_s = row[1]
+        max_age = timedelta(seconds=max_age_s)
+        session = MegolmOutboundSession.from_pickle(
+            session_data, devices, max_age, row[2], row[3], row[4], self.pickle_key)
+        if sessions is not None:
+            sessions[room_id] = session
+        return session
+
+    def remove_outbound_session(self, room_id):
+        """Removes a saved outbound Megolm session.
+
+        Args:
+            room_id (str): The room corresponding to the session.
+        """
+        c = self.conn.cursor()
+        c.execute('DELETE FROM megolm_outbound_sessions WHERE device_id=? AND room_id=?',
+                  (self.device_id, room_id))
+        c.close()
+        self.conn.commit()
+
+    def save_megolm_outbound_devices(self, room_id, device_ids):
+        """Saves devices an outbound Megolm session is shared with.
+
+        Args:
+            room_id (str): The room corresponding to the session.
+            device_ids (iterable): A list of device ids.
+        """
+        c = self.conn.cursor()
+        rows = [(self.device_id, room_id, device_id) for device_id in device_ids]
+        c.executemany(
+            'INSERT OR IGNORE INTO megolm_outbound_devices VALUES (?,?,?)', rows)
+        c.close()
+        self.conn.commit()
 
     def close(self):
         self.conn.close()

--- a/matrix_client/crypto/crypto_store.py
+++ b/matrix_client/crypto/crypto_store.py
@@ -48,6 +48,11 @@ class CryptoStore(object):
                   'session_id TEXT PRIMARY KEY, curve_key TEXT, session BLOB,'
                   'FOREIGN KEY(device_id) REFERENCES accounts(device_id) '
                   'ON DELETE CASCADE)')
+        c.execute('CREATE TABLE IF NOT EXISTS megolm_inbound_sessions '
+                  '(device_id TEXT, session_id TEXT PRIMARY KEY, room_id TEXT,'
+                  'curve_key TEXT, session BLOB,'
+                  'FOREIGN KEY(device_id) REFERENCES accounts(device_id) '
+                  'ON DELETE CASCADE)')
         c.close()
         self.conn.commit()
 
@@ -154,6 +159,71 @@ class CryptoStore(object):
         c.close()
         # For consistency with other get_ methods, do not return an empty list
         return sessions or None
+
+    def save_inbound_session(self, room_id, curve_key, session):
+        """Saves a Megolm inbound session.
+
+        Args:
+            room_id (str): The room corresponding to the session.
+            curve_key (str): The curve25519 key of the device.
+            session (olm.InboundGroupSession): The session to save.
+        """
+        c = self.conn.cursor()
+        c.execute('REPLACE INTO megolm_inbound_sessions VALUES (?,?,?,?,?)',
+                  (self.device_id, session.id, room_id, curve_key,
+                   session.pickle(self.pickle_key)))
+        c.close()
+        self.conn.commit()
+
+    def load_inbound_sessions(self, sessions):
+        """Loads all saved inbound Megolm sessions.
+
+        Args:
+            sessions (defaultdict(defaultdict(dict))): An object which will get
+                populated with the sessions. The format is
+                ``{<room_id>: {<curve25519_key>: {<session_id>:
+                <olm.InboundGroupSession>}}}``.
+        """
+        c = self.conn.cursor()
+        rows = c.execute(
+            'SELECT room_id, curve_key, session FROM megolm_inbound_sessions WHERE '
+            'device_id=?', (self.device_id,)
+        )
+        for row in rows:
+            session = olm.InboundGroupSession.from_pickle(bytes(row[2]), self.pickle_key)
+            sessions[row[0]][row[1]][session.id] = session
+        c.close()
+
+    def get_inbound_session(self, room_id, curve_key, session_id, sessions=None):
+        """Gets a saved inbound Megolm session.
+
+        Args:
+            room_id (str): The room corresponding to the session.
+            curve_key (str): The curve25519 key of the device.
+            session_id (str): The id of the session.
+            sessions (dict): Optional. A map from session id to olm.InboundGroupSession
+                object, to which the session will be added.
+
+        Returns:
+            olm.InboundGroupSession object, or None if the session was not found.
+        """
+        c = self.conn.cursor()
+        c.execute(
+            'SELECT session FROM megolm_inbound_sessions WHERE device_id=? AND room_id=? '
+            'AND curve_key=? AND session_id=?',
+            (self.device_id, room_id, curve_key, session_id)
+        )
+        try:
+            session_data = c.fetchone()[0]
+            session_data = bytes(session_data)
+        except TypeError:
+            return None
+        finally:
+            c.close()
+        session = olm.InboundGroupSession.from_pickle(session_data, self.pickle_key)
+        if sessions is not None:
+            sessions[session.id] = session
+        return session
 
     def close(self):
         self.conn.close()

--- a/matrix_client/crypto/crypto_store.py
+++ b/matrix_client/crypto/crypto_store.py
@@ -222,8 +222,7 @@ class CryptoStore(object):
         """
         c = self.conn.cursor()
         rows = c.execute(
-            'SELECT room_id, curve_key, session FROM megolm_inbound_sessions WHERE '
-            'device_id=?', (self.device_id,)
+            'SELECT * FROM megolm_inbound_sessions WHERE device_id=?', (self.device_id,)
         )
         for row in rows:
             session = olm.InboundGroupSession.from_pickle(bytes(row[2]), self.pickle_key)
@@ -291,10 +290,7 @@ class CryptoStore(object):
         """
         c = self.conn.cursor()
         rows = c.execute(
-            'SELECT room_id, session, max_age_s, max_messages, creation_time,'
-            'message_count FROM megolm_outbound_sessions WHERE device_id=?',
-            (self.device_id,)
-        )
+            'SELECT * FROM megolm_outbound_sessions WHERE device_id=?', (self.device_id,))
         for row in rows.fetchall():
             device_ids = c.execute(
                 'SELECT user_device_id FROM megolm_outbound_devices WHERE device_id=? '
@@ -325,8 +321,7 @@ class CryptoStore(object):
         """
         c = self.conn.cursor()
         c.execute(
-            'SELECT session, max_age_s, max_messages, creation_time, message_count '
-            'FROM megolm_outbound_sessions WHERE device_id=? AND room_id=?',
+            'SELECT * FROM megolm_outbound_sessions WHERE device_id=? AND room_id=?',
             (self.device_id, room_id)
         )
         try:
@@ -402,9 +397,7 @@ class CryptoStore(object):
         """
         c = self.conn.cursor()
         rows = c.execute(
-            'SELECT user_id, user_device_id, ed_key, curve_key FROM device_keys '
-            'WHERE device_id=?', (self.device_id,)
-        )
+            'SELECT * FROM device_keys WHERE device_id=?', (self.device_id,))
         for row in rows:
             device_keys[row[0]][row[1]] = {
                 'ed25519': row[2],
@@ -428,15 +421,14 @@ class CryptoStore(object):
         for user_id in user_devices:
             if not user_devices[user_id]:
                 c.execute(
-                    'SELECT user_id, user_device_id, ed_key, curve_key FROM device_keys '
-                    'WHERE device_id=? AND user_id=?', (self.device_id, user_id)
+                    'SELECT * FROM device_keys WHERE device_id=? AND user_id=?',
+                    (self.device_id, user_id)
                 )
                 rows.extend(c.fetchall())
             else:
                 for device_id in user_devices[user_id]:
                     c.execute(
-                        'SELECT user_id, user_device_id, ed_key, curve_key FROM '
-                        'device_keys WHERE device_id=? AND user_id=? AND '
+                        'SELECT * FROM device_keys WHERE device_id=? AND user_id=? AND '
                         'user_device_id=?', (self.device_id, user_id, device_id)
                     )
                     rows.extend(c.fetchall())

--- a/matrix_client/crypto/device_list.py
+++ b/matrix_client/crypto/device_list.py
@@ -1,0 +1,269 @@
+import logging
+from collections import defaultdict
+from threading import Thread, Condition, Event
+
+from matrix_client.errors import MatrixHttpLibError, MatrixRequestError
+
+logger = logging.getLogger(__name__)
+
+
+class DeviceList:
+    """Allows to maintain a list of devices up-to-date for an OlmDevice.
+
+    Offers blocking and non-blocking methods to fetch device keys when appropriate.
+    NOTE: Spawns a thread that will last until program termination.
+
+    Args:
+        olm_device (OlmDevice): Will be used to get additional info, such as device id.
+        api (MatrixHttpApi): The api object used to make requests.
+        device_keys (defaultdict(dict)): A map from user to device to keys.
+    """
+
+    def __init__(self, olm_device, api, device_keys):
+        self.olm_device = olm_device
+        self.api = api
+        self.device_keys = device_keys
+        # Stores the ids of users who need updating
+        self.outdated_user_ids = _OutdatedUsersSet()
+        # Stores the ids of users we are currently tracking. We can assume the device
+        # keys of these users are up-to-date as long as no downloading is in progress.
+        # We should track every user we share an encrypted room with.
+        self.tracked_user_ids = set()
+        # Allows to wake up the thread when there are new users to update, and to
+        # synchronise shared data.
+        self.thread_condition = Condition()
+        self.update_thread = _UpdateDeviceList(
+            self.thread_condition, self.outdated_user_ids, self._download_device_keys,
+            self.tracked_user_ids
+        )
+        self.update_thread.start()
+
+    def get_room_device_keys(self, room, blocking=True):
+        """Gets the keys of all devices present in the room.
+
+        Makes sure not to download keys of users we are already tracking.
+        The users we were not yet tracking will get tracked automatically.
+
+        Args:
+            room (Room): The room to use.
+            blocking (bool): Optional. Whether to wait for the keys to have been
+                downloaded before returning.
+        """
+        logger.info('Fetching all missing keys in room %s.', room.room_id)
+        user_ids = {u.user_id for u in room.get_joined_members()} - self.tracked_user_ids
+        if not user_ids:
+            logger.info('Already had all the keys in room %s.', room.room_id)
+            if blocking:
+                # Wait on an eventual download to finish
+                self.update_thread.event.wait()
+            return
+        with self.thread_condition:
+            self.outdated_user_ids.update(user_ids)
+            if blocking:
+                # Will ensure the user_ids we just added are processed
+                event = Event()
+                self.outdated_user_ids.events.add(event)
+            self.thread_condition.notify()
+        if blocking:
+            event.wait()
+
+    def add_users(self, user_ids):
+        """Add users to be tracked, and download their device keys.
+
+        NOTE: this is non-blocking and will return before the keys are downloaded.
+
+        Args:
+            user_ids (iterable): Any iterable containing user ids.
+        """
+        user_ids = user_ids.difference(self.tracked_user_ids)
+        if user_ids:
+            self._add_outdated_users(user_ids)
+
+    def stop_tracking_users(self, user_ids):
+        """Stop tracking users.
+
+        NOTE: Keys will not be deleted.
+
+        Args:
+            user_ids (iterable): Any iterable containing user ids.
+        """
+        with self.thread_condition:
+            self.tracked_user_ids.difference_update(user_ids)
+            self.outdated_user_ids.difference_update(user_ids)
+        logger.info('Stopped tracking users: %s.', user_ids)
+
+    def update_user_device_keys(self, user_ids, since_token=None):
+        """Triggers an update for users we already track.
+
+        Args:
+            user_ids (iterable): Any iterable containing user ids.
+            since_token (str): Optional. Since token of a sync request, if triggering
+                the update as a result of that sync request.
+        """
+        user_ids = self.tracked_user_ids.intersection(user_ids)
+        if not user_ids:
+            return
+        logger.info('Updating the device lists of users: %s, using token %s',
+                    user_ids, since_token)
+        self._add_outdated_users(user_ids, since_token=since_token)
+
+    def _add_outdated_users(self, user_ids, since_token=None):
+        """Stop tracking users. Keys will not be deleted.
+
+        Args:
+            user_ids (iterable): Any iterable containing user ids.
+            since_token (str): Optional. Since token of a sync request.
+        """
+        with self.thread_condition:
+            self.outdated_user_ids.update(user_ids)
+            if since_token:
+                self.outdated_user_ids.sync_token = since_token
+            self.thread_condition.notify()
+
+    def _download_device_keys(self, user_devices, since_token=None):
+        """Download and store device keys, if they pass security checks.
+
+        Args:
+            user_devices (dict): Format is ``user_id: [device_ids]``.
+            since_token (str): Optional. Since token of a sync request.
+        """
+        changed = defaultdict(dict)
+        resp = self.api.query_keys(user_devices, token=since_token)
+        if resp.get('failures'):
+            logger.warning('Failed to download keys from the following unreachable '
+                           'homeservers %s.', resp['failures'])
+        device_keys = resp['device_keys']
+        for user_id in user_devices:
+            # The response might not contain every user_ids we requested
+            for device_id, payload in device_keys.get(user_id, {}).items():
+                if device_id == self.olm_device.device_id:
+                    continue
+                if payload['user_id'] != user_id or payload['device_id'] != device_id:
+                    logger.warning('Mismatch in keys payload of device %s (%s) of user '
+                                   '%s (%s).', payload['device_id'], device_id,
+                                   payload['user_id'], user_id)
+                    continue
+                try:
+                    signing_key = payload['keys']['ed25519:{}'.format(device_id)]
+                    curve_key = payload['keys']['curve25519:{}'.format(device_id)]
+                except KeyError as e:
+                    logger.warning('Invalid identity keys payload from device %s of'
+                                   'user %s: %s.', device_id, user_id, e)
+                    continue
+                verified = self.olm_device.verify_json(
+                    payload, signing_key, user_id, device_id)
+                if not verified:
+                    logger.warning('Signature verification failed for device %s of '
+                                   'user %s.', device_id, user_id)
+                    continue
+                keys = self.device_keys[user_id].setdefault(device_id, {})
+                if keys:
+                    if keys['ed25519'] != signing_key:
+                        logger.warning('Ed25519 key has changed for device %s of '
+                                       'user %s.', device_id, user_id)
+                        continue
+                    if keys['curve25519'] == curve_key:
+                        continue
+                else:
+                    keys['ed25519'] = signing_key
+                keys['curve25519'] = curve_key
+                changed[user_id][device_id] = keys
+
+        logger.info('Successfully downloaded keys for devices: %s.',
+                    {user_id: list(changed[user_id]) for user_id in changed})
+        return changed
+
+
+class _OutdatedUsersSet(set):
+    """Allows to know if elements in a set have been processed.
+
+    This is done by adding elements along with an Event object. Then, functions
+    processing the set should set the events when they are done.
+    """
+
+    def __init__(self, iterable=()):
+        self.events = set()
+        self._sync_token = None
+        super(_OutdatedUsersSet, self).__init__(iterable)
+
+    def mark_as_processed(self):
+        for event in self.events:
+            event.set()
+
+    def copy(self):
+        new_set = _OutdatedUsersSet(self)
+        new_set.events = self.events.copy()
+        return new_set
+
+    def clear(self):
+        self.events.clear()
+        super(_OutdatedUsersSet, self).clear()
+
+    def update(self, iterable):
+        super(_OutdatedUsersSet, self).update(iterable)
+        if isinstance(iterable, _OutdatedUsersSet):
+            self.events.update(iterable.events)
+
+    @property
+    def sync_token(self):
+        return self._sync_token
+
+    @sync_token.setter
+    def sync_token(self, token):
+        if not self._sync_token or token > self._sync_token:
+            self._sync_token = token
+
+
+class _UpdateDeviceList(Thread):
+
+    def __init__(self, cond, user_ids, download_method, tracked_user_ids):
+        # We wait on this condition when there is nothing to do. Outside code should use
+        # it to notify us when they add data to be processed in outdated_user_ids so that
+        # we can wake up and process it.
+        self.cond = cond
+        self.outdated_user_ids = user_ids
+        self.download = download_method
+        self.tracked_user_ids = tracked_user_ids
+        # Cleared when we start a download, and set when we have finished it. This can be
+        # used by outside code in order to know if we are in the middle of a download, and
+        # allows to wait for it to complete by waiting on this event.
+        self.event = Event()
+        # Used internally to terminate gracefully on program exit.
+        self._should_terminate = Event()
+        super(_UpdateDeviceList, self).__init__()
+
+    def run(self):
+        while True and not self._should_terminate.is_set():
+            with self.cond:
+                while not self.outdated_user_ids:
+                    # Avoid any deadlocks
+                    self.outdated_user_ids.mark_as_processed()
+                    self.event.set()
+                    logger.debug('Update thread is going to sleep...')
+                    self.cond.wait()
+                    logger.debug('Update thread woke up!')
+                    if self._should_terminate.is_set():
+                        return
+                to_download = self.outdated_user_ids.copy()
+                self.outdated_user_ids.clear()
+                self.event.clear()
+                self.tracked_user_ids.update(to_download)
+            payload = {user_id: [] for user_id in to_download}
+            logger.info('Downloading device keys for users: %s.', to_download)
+            try:
+                self.download(payload, self.outdated_user_ids.sync_token)
+                self.event.set()
+                to_download.mark_as_processed()
+            except (MatrixHttpLibError, MatrixRequestError) as e:
+                logger.warning('Network error when fetching device keys (will retry): %s',
+                               e)
+                with self.cond:
+                    self.outdated_user_ids.update(to_download)
+
+    def join(self, timeout=None):
+        # If we are joined, this means that the main program is terminating.
+        # We should terminate too.
+        self._should_terminate.set()
+        with self.cond:
+            self.cond.notify()
+        super(_UpdateDeviceList, self).join(timeout=timeout)

--- a/matrix_client/crypto/megolm_outbound_session.py
+++ b/matrix_client/crypto/megolm_outbound_session.py
@@ -12,15 +12,19 @@ class MegolmOutboundSession(OutboundGroupSession):
 
     Args:
         max_age (datetime.timedelta): Optional. The maximum time the session should
-            exist.
+            exist. Default to one week if not present.
         max_messages (int): Optional. The maximum number of messages that should be sent.
             A new message in considered sent each time there is a call to ``encrypt``.
+            Default to 100 if not present.
     """
 
-    def __init__(self, max_age=timedelta(days=7), max_messages=100):
+    def __init__(self, max_age=None, max_messages=None):
         self.devices = set()
-        self.max_age = max_age
-        self.max_messages = max_messages
+        if max_age:
+            self.max_age = timedelta(milliseconds=max_age)
+        else:
+            self.max_age = timedelta(days=7)
+        self.max_messages = max_messages or 100
         self.creation_time = datetime.now()
         self.message_count = 0
         super(MegolmOutboundSession, self).__init__()

--- a/matrix_client/crypto/megolm_outbound_session.py
+++ b/matrix_client/crypto/megolm_outbound_session.py
@@ -1,0 +1,56 @@
+from datetime import datetime, timedelta
+
+from olm import OutboundGroupSession
+
+
+class MegolmOutboundSession(OutboundGroupSession):
+
+    """Outbound group session aware of the users it is shared with.
+
+    Also remembers the time it was created and the number of messages it has encrypted,
+    in order to know if it needs to be rotated.
+
+    Args:
+        max_age (datetime.timedelta): Optional. The maximum time the session should
+            exist.
+        max_messages (int): Optional. The maximum number of messages that should be sent.
+            A new message in considered sent each time there is a call to ``encrypt``.
+    """
+
+    def __init__(self, max_age=timedelta(days=7), max_messages=100):
+        self.devices = set()
+        self.max_age = max_age
+        self.max_messages = max_messages
+        self.creation_time = datetime.now()
+        self.message_count = 0
+        super(MegolmOutboundSession, self).__init__()
+
+    def __new__(cls, **kwargs):
+        return super(MegolmOutboundSession, cls).__new__(cls)
+
+    def add_device(self, device_id):
+        """Adds a device the session is shared with."""
+        self.devices.add(device_id)
+
+    def add_devices(self, device_ids):
+        """Adds devices the session is shared with.
+
+        Args:
+            device_ids (iterable): An iterable of device ids, preferably a set.
+        """
+        self.devices.update(device_ids)
+
+    def should_rotate(self):
+        """Wether the session should be rotated.
+
+        Returns:
+            True if it should, False if not.
+        """
+        if self.message_count >= self.max_messages or \
+                datetime.now() - self.creation_time >= self.max_age:
+            return True
+        return False
+
+    def encrypt(self, plaintext):
+        self.message_count += 1
+        return super(MegolmOutboundSession, self).encrypt(plaintext)

--- a/matrix_client/crypto/megolm_outbound_session.py
+++ b/matrix_client/crypto/megolm_outbound_session.py
@@ -16,6 +16,10 @@ class MegolmOutboundSession(OutboundGroupSession):
         max_messages (int): Optional. The maximum number of messages that should be sent.
             A new message in considered sent each time there is a call to ``encrypt``.
             Default to 100 if not present.
+
+    Attributes:
+        creation_time (datetime.datetime): Creation time of the session.
+        message_count (int): Number of messages encrypted using the session.
     """
 
     def __init__(self, max_age=None, max_messages=None):
@@ -58,3 +62,14 @@ class MegolmOutboundSession(OutboundGroupSession):
     def encrypt(self, plaintext):
         self.message_count += 1
         return super(MegolmOutboundSession, self).encrypt(plaintext)
+
+    @classmethod
+    def from_pickle(cls, pickle, devices, max_age, max_messages, creation_time,
+                    message_count, passphrase=''):
+        session = super(MegolmOutboundSession, cls).from_pickle(pickle, passphrase)
+        session.devices = devices
+        session.max_age = max_age
+        session.max_messages = max_messages
+        session.creation_time = creation_time
+        session.message_count = message_count
+        return session

--- a/matrix_client/crypto/olm_device.py
+++ b/matrix_client/crypto/olm_device.py
@@ -1,10 +1,12 @@
 import logging
+from collections import defaultdict
 
 import olm
 from canonicaljson import encode_canonical_json
 
 from matrix_client.checks import check_user_id
 from matrix_client.crypto.one_time_keys import OneTimeKeysManager
+from matrix_client.crypto.device_list import DeviceList
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +61,8 @@ class OlmDevice(object):
         self.one_time_keys_manager = OneTimeKeysManager(target_keys_number,
                                                         signed_keys_proportion,
                                                         keys_threshold)
+        self.device_keys = defaultdict(dict)
+        self.device_list = DeviceList(self, api, self.device_keys)
 
     def upload_identity_keys(self):
         """Uploads this device's identity keys to HS.

--- a/matrix_client/crypto/olm_device.py
+++ b/matrix_client/crypto/olm_device.py
@@ -508,6 +508,20 @@ class OlmDevice(object):
         }
         return encrypted_event
 
+    def megolm_remove_outbound_session(self, room_id):
+        """Remove an existing Megolm outbound session in a room.
+
+        If there is no such session, nothing will happen.
+
+        Args:
+            room_id (str): The room to use.
+        """
+        try:
+            self.megolm_outbound_sessions.pop(room_id)
+            logger.info('Removed Meglom outbound session in %s.', room_id)
+        except KeyError:
+            pass
+
     def sign_json(self, json):
         """Signs a JSON object.
 

--- a/matrix_client/crypto/olm_device.py
+++ b/matrix_client/crypto/olm_device.py
@@ -663,8 +663,8 @@ class OlmDevice(object):
                 'event_id': event['event_id']
             }
         else:
-            if properties['origin_server_ts'] == event['origin_server_ts'] and \
-                    properties['event_id'] == event['event_id']:
+            if properties['origin_server_ts'] != event['origin_server_ts'] or \
+                    properties['event_id'] != event['event_id']:
                 raise RuntimeError('Detected a replay attack from device {} of user {} '
                                    'on decrypted event: {}.'.format(device_id, user_id,
                                                                     decrypted_event))

--- a/matrix_client/crypto/olm_device.py
+++ b/matrix_client/crypto/olm_device.py
@@ -401,7 +401,8 @@ class OlmDevice(object):
         Returns:
             The newly created session.
         """
-        session = MegolmOutboundSession()
+        session = MegolmOutboundSession(max_age=room.rotation_period_ms,
+                                        max_messages=room.rotation_period_msgs)
         self.megolm_outbound_sessions[room.room_id] = session
         logger.info('Starting a new Meglom outbound session %s in %s.',
                     session.id, room.room_id)

--- a/matrix_client/crypto/olm_device.py
+++ b/matrix_client/crypto/olm_device.py
@@ -371,6 +371,25 @@ class OlmDevice(object):
 
         return json.loads(event)
 
+    def olm_ensure_sessions(self, user_devices):
+        """Start Olm sessions with the given devices if one doesn't exist already.
+
+        Args:
+            user_devices (dict): A map from user ids to a list of device ids.
+        """
+        user_devices_no_session = defaultdict(list)
+        for user_id in user_devices:
+            for device_id in user_devices[user_id]:
+                curve_key = self.device_keys[user_id][device_id]['curve25519']
+                # Check if we have a list of sessions for this device, which can be
+                # empty. Implicitely, an empty list will indicate that we already tried
+                # to establish a session with a device, but this attempt was
+                # unsuccessful. We do not retry to establish a session.
+                if curve_key not in self.olm_sessions:
+                    user_devices_no_session[user_id].append(device_id)
+        if user_devices_no_session:
+            self.olm_start_sessions(user_devices_no_session)
+
     def sign_json(self, json):
         """Signs a JSON object.
 

--- a/matrix_client/crypto/olm_device.py
+++ b/matrix_client/crypto/olm_device.py
@@ -522,6 +522,21 @@ class OlmDevice(object):
         except KeyError:
             pass
 
+    def send_encrypted_message(self, room, content):
+        """Send a m.room.encrypted event in a room.
+
+        Args:
+            room (Room): The room to use.
+            content (dict): The content of the event, will be encrypted.
+
+        Raises:
+            MatrixRequestError if there was an error sending the event.
+        """
+        event = {'content': content, 'room_id': room.room_id, 'type': 'm.room.message'}
+        encrypted_event = self.megolm_build_encrypted_event(room, event)
+        return self.api.send_message_event(
+            room.room_id, 'm.room.encrypted', encrypted_event)
+
     def sign_json(self, json):
         """Signs a JSON object.
 

--- a/matrix_client/crypto/olm_device.py
+++ b/matrix_client/crypto/olm_device.py
@@ -69,12 +69,14 @@ class OlmDevice(object):
         self.olm_sessions = defaultdict(list)
         self.megolm_inbound_sessions = defaultdict(lambda: defaultdict(dict))
         self.megolm_outbound_sessions = {}
+        self.device_keys = defaultdict(dict)
         self.olm_account = self.db.get_olm_account()
         if self.olm_account:
             if load_all:
                 self.db.load_olm_sessions(self.olm_sessions)
                 self.db.load_inbound_sessions(self.megolm_inbound_sessions)
                 self.db.load_outbound_sessions(self.megolm_outbound_sessions)
+                self.db.load_device_keys(self.device_keys)
             logger.info('Loaded Olm account from database for device %s.', device_id)
         else:
             self.olm_account = olm.Account()
@@ -89,8 +91,7 @@ class OlmDevice(object):
         self.one_time_keys_manager = OneTimeKeysManager(target_keys_number,
                                                         signed_keys_proportion,
                                                         keys_threshold)
-        self.device_keys = defaultdict(dict)
-        self.device_list = DeviceList(self, api, self.device_keys)
+        self.device_list = DeviceList(self, api, self.device_keys, self.db)
         self.megolm_index_record = defaultdict(dict)
 
     def upload_identity_keys(self):
@@ -447,9 +448,9 @@ class OlmDevice(object):
                     session.id, room.room_id)
 
         users = room.get_joined_members()
+        self.device_list.get_room_device_keys(room)
         user_devices = {user.user_id: list(self.device_keys[user.user_id])
                         for user in users}
-        self.device_list.get_room_device_keys(room)
         self.db.remove_outbound_session(room.room_id)
         self.db.save_outbound_session(room.room_id, session)
         self.megolm_share_session(room.room_id, user_devices, session)

--- a/matrix_client/errors.py
+++ b/matrix_client/errors.py
@@ -46,3 +46,10 @@ class MatrixHttpLibError(MatrixError):
                                                                   original_exception)
         )
         self.original_exception = original_exception
+
+
+class MatrixNoEncryptionError(MatrixError):
+    """Encryption was not available."""
+
+    def __init__(self, content=""):
+        super(MatrixNoEncryptionError, self).__init__(content)

--- a/matrix_client/room.py
+++ b/matrix_client/room.py
@@ -668,6 +668,12 @@ class Room(object):
                         self.client.olm_device.device_list.track_user_no_download(user_id)
                 elif econtent["membership"] in ("leave", "kick", "invite"):
                     self._members.pop(user_id, None)
+                    if econtent["membership"] != "invite":
+                        if self.client._encryption and self.encrypted:
+                            # Invalidate any outbound session we have in the room when
+                            # someone leaves
+                            self.client.olm_device.megolm_remove_outbound_session(
+                                self.room_id)
 
         for listener in self.state_listeners:
             if (

--- a/matrix_client/room.py
+++ b/matrix_client/room.py
@@ -50,6 +50,8 @@ class Room(object):
             # user_id: displayname
         }
         self.encrypted = False
+        self.rotation_period_msgs = None
+        self.rotation_period_ms = None
 
     def set_user_profile(self,
                          displayname=None,
@@ -692,6 +694,10 @@ class Room(object):
             elif etype == "m.room.encryption":
                 if econtent.get("algorithm") == "m.megolm.v1.aes-sha2":
                     self.encrypted = True
+                    if not self.rotation_period_ms:
+                        self.rotation_period_ms = econtent.get("rotation_period_ms")
+                    if not self.rotation_period_msgs:
+                        self.rotation_period_msgs = econtent.get("rotation_period_msgs")
             elif etype == "m.room.member" and clevel == clevel.ALL:
                 # tracking room members can be large e.g. #matrix:matrix.org
                 user_id = state_event["state_key"]

--- a/matrix_client/room.py
+++ b/matrix_client/room.py
@@ -660,11 +660,14 @@ class Room(object):
                     self.encrypted = True
             elif etype == "m.room.member" and clevel == clevel.ALL:
                 # tracking room members can be large e.g. #matrix:matrix.org
+                user_id = state_event["state_key"]
                 if econtent["membership"] == "join":
-                    user_id = state_event["state_key"]
                     self._add_member(user_id, econtent.get("displayname"))
+                    if self.client._encryption and self.encrypted:
+                        # Track the device list of this user
+                        self.client.olm_device.device_list.track_user_no_download(user_id)
                 elif econtent["membership"] in ("leave", "kick", "invite"):
-                    self._members.pop(state_event["state_key"], None)
+                    self._members.pop(user_id, None)
 
         for listener in self.state_listeners:
             if (

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         'test': ['pytest', 'responses'],
         'doc': ['Sphinx==1.4.6', 'sphinx-rtd-theme==0.1.9', 'sphinxcontrib-napoleon==0.5.3'],
         'format': ['flake8'],
-        'e2e': ['python-olm==dev', 'canonicaljson']
+        'e2e': ['python-olm==dev', 'canonicaljson', 'appdirs']
     },
     dependency_links=[
         'git+https://github.com/poljar/python-olm.git@4752eb22f005cb9f6143857008572e6d83252841#egg=python-olm-dev'

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -1,16 +1,19 @@
 import pytest
 import responses
 import json
+import matrix_client.client
 from copy import deepcopy
 from matrix_client.client import MatrixClient, Room, User, CACHE
 from matrix_client.api import MATRIX_V2_API_PATH
 from . import response_examples
+from .crypto.dummy_olm_device import OlmDevice
 try:
     from urllib import quote
 except ImportError:
     from urllib.parse import quote
 
 HOSTNAME = "http://example.com"
+matrix_client.client.OlmDevice = OlmDevice
 
 
 def test_create_client():

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -536,6 +536,15 @@ def test_enable_encryption_in_room():
     assert room.enable_encryption()
     assert room.encrypted
 
+    room = client._mkroom(room_id)
+    assert room.enable_encryption(rotation_period_msgs=1, rotation_period_ms=1)
+    assert room.rotation_period_msgs == 1
+    assert room.rotation_period_ms == 1
+
+    assert room.enable_encryption(rotation_period_msgs=2)
+    # The room was already encrypted, we should not have changed its attribute
+    assert room.rotation_period_msgs == 1
+
 
 @responses.activate
 def test_detect_encryption_state():

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -571,6 +571,7 @@ def test_detect_encryption_state():
 @responses.activate
 def test_one_time_keys_sync():
     client = MatrixClient(HOSTNAME, encryption=True)
+    client.first_sync = False
     sync_url = HOSTNAME + MATRIX_V2_API_PATH + "/sync"
     sync_response = deepcopy(response_examples.example_sync)
     payload = {'dummy': 1}

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -155,13 +155,30 @@ def test_state_event():
     # test encryption
     room.encrypted = False
     ev["type"] = "m.room.encryption"
-    ev["content"] = {"algorithm": "m.megolm.v1.aes-sha2"}
+    ev["content"] = {
+        "algorithm": "m.megolm.v1.aes-sha2",
+        "rotation_period_msgs": 50,
+        "rotation_period_ms": 100000,
+    }
     room._process_state_event(ev)
     assert room.encrypted
+    assert room.rotation_period_ms == 100000
+    assert room.rotation_period_msgs == 50
     # encrypted flag must not be cleared on configuration change
     ev["content"] = {"algorithm": None}
     room._process_state_event(ev)
     assert room.encrypted
+    assert room.rotation_period_ms == 100000
+    assert room.rotation_period_msgs == 50
+    # nor should the session parameters be changed
+    ev["content"] = {
+        "algorithm": "m.megolm.v1.aes-sha2",
+        "rotation_period_msgs": 5,
+        "rotation_period_ms": 10000,
+    }
+    room._process_state_event(ev)
+    assert room.rotation_period_ms == 100000
+    assert room.rotation_period_msgs == 50
 
 
 def test_get_user():

--- a/test/crypto/crypto_store_test.py
+++ b/test/crypto/crypto_store_test.py
@@ -1,0 +1,49 @@
+import pytest
+olm = pytest.importorskip("olm")  # noqa
+
+import os
+from tempfile import mkdtemp
+
+from matrix_client.crypto.crypto_store import CryptoStore
+from matrix_client.crypto.olm_device import OlmDevice
+
+
+class TestCryptoStore(object):
+
+    # Initialise a store and test some init code
+    device_id = 'AUIETSRN'
+    user_id = '@user:matrix.org'
+    db_name = 'test.db'
+    db_path = mkdtemp()
+    store_conf = {
+        'db_name': db_name,
+        'db_path': db_path
+    }
+    store = CryptoStore(device_id, db_path=db_path, db_name=db_name)
+    db_filepath = os.path.join(db_path, db_name)
+    assert os.path.exists(db_filepath)
+    store.close()
+    store = CryptoStore(device_id, db_path=db_path, db_name='test.db')
+
+    @pytest.fixture(autouse=True, scope='class')
+    def cleanup(self):
+        yield
+        os.remove(self.db_filepath)
+
+    def test_olm_account_persistence(self):
+        account = olm.Account()
+        identity_keys = account.identity_keys
+        self.store.remove_olm_account()
+
+        # Try to load inexisting account
+        saved_account = self.store.get_olm_account()
+        assert saved_account is None
+
+        # Save and load
+        self.store.save_olm_account(account)
+        saved_account = self.store.get_olm_account()
+        assert saved_account.identity_keys == identity_keys
+
+        # Load the account from an OlmDevice
+        device = OlmDevice(None, self.user_id, self.device_id, store_conf=self.store_conf)
+        assert device.olm_account.identity_keys == account.identity_keys

--- a/test/crypto/device_list_test.py
+++ b/test/crypto/device_list_test.py
@@ -1,0 +1,272 @@
+import pytest
+pytest.importorskip("olm")  # noqa
+
+import json
+from copy import deepcopy
+from threading import Event, Condition
+
+import responses
+
+from matrix_client.api import MATRIX_V2_API_PATH
+from matrix_client.client import MatrixClient
+from matrix_client.room import User
+from matrix_client.errors import MatrixRequestError
+from matrix_client.crypto.olm_device import OlmDevice
+from matrix_client.crypto.device_list import (_OutdatedUsersSet as OutdatedUsersSet,
+                                              _UpdateDeviceList as UpdateDeviceList)
+from test.response_examples import example_key_query_response
+
+HOSTNAME = 'http://example.com'
+
+
+class TestDeviceList:
+    cli = MatrixClient(HOSTNAME)
+    user_id = '@test:example.com'
+    alice = '@alice:example.com'
+    room_id = '!test:example.com'
+    device_id = 'AUIETSRN'
+    device = OlmDevice(cli.api, user_id, device_id)
+    device_list = device.device_list
+    signing_key = device.olm_account.identity_keys['ed25519']
+    query_url = HOSTNAME + MATRIX_V2_API_PATH + '/keys/query'
+
+    @responses.activate
+    def test_download_device_keys(self):
+        # The method we want to test
+        download_device_keys = self.device_list._download_device_keys
+        bob = '@bob:example.com'
+        eve = '@eve:example.com'
+        user_devices = {self.alice: [], bob: [], self.user_id: []}
+
+        # This response is correct for Alice's keys, but lacks Bob's
+        # There are no failures
+        resp = example_key_query_response
+        responses.add(responses.POST, self.query_url, json=resp)
+
+        # Still correct, but Alice's identity key has changed
+        resp = deepcopy(example_key_query_response)
+        new_id_key = 'ijxGZqwB/UvMtKABdaCdrI0OtQI6NhHBYiknoCkdWng'
+        payload = resp['device_keys'][self.alice]['JLAFKJWSCS']
+        payload['keys']['curve25519:JLAFKJWSCS'] = new_id_key
+        payload['signatures'][self.alice]['ed25519:JLAFKJWSCS'] = \
+            ('D9oLtYefMIr4StiHTIzn3+bhtPCfrZNDU9jsUbMu3MicfZLl4d8WlYn3TPmbwDi8XMGcT'
+             'nNnqfdi/tYUPvKfCA')
+        responses.add(responses.POST, self.query_url, json=resp)
+
+        # Still correct, but Alice's signing key has changed
+        alice_device = OlmDevice(self.cli.api, self.alice, 'JLAFKJWSCS')
+        resp = deepcopy(example_key_query_response)
+        resp['device_keys'][self.alice]['JLAFKJWSCS']['keys']['ed25519:JLAFKJWSCS'] = \
+            alice_device.identity_keys['ed25519']
+        resp['device_keys'][self.alice]['JLAFKJWSCS'] = \
+            alice_device.sign_json(resp['device_keys'][self.alice]['JLAFKJWSCS'])
+        responses.add(responses.POST, self.query_url, json=resp)
+
+        # Response containing an unknown user
+        resp = deepcopy(example_key_query_response)
+        user_device = resp['device_keys'].pop(self.alice)
+        resp['device_keys'][eve] = user_device
+        responses.add(responses.POST, self.query_url, json=resp)
+
+        # Response with an invalid signature
+        resp = deepcopy(example_key_query_response)
+        resp['device_keys'][self.alice]['JLAFKJWSCS']['test'] = 1
+        responses.add(responses.POST, self.query_url, json=resp)
+
+        # Response with a requested user and valid signature, but with a mismatch
+        resp = deepcopy(example_key_query_response)
+        user_device = resp['device_keys'].pop(self.alice)
+        resp['device_keys'][bob] = user_device
+        responses.add(responses.POST, self.query_url, json=resp)
+
+        # Response with an invalid keys field
+        resp = deepcopy(example_key_query_response)
+        keys_field = resp['device_keys'][self.alice]['JLAFKJWSCS']['keys']
+        key = keys_field.pop("ed25519:JLAFKJWSCS")
+        keys_field["ed25519:wrong"] = key
+        # Cover a missing branch by adding failures
+        resp["failures"]["other.com"] = {}
+        # And one more by adding ourself
+        resp['device_keys'][self.user_id] = {self.device_id: 'dummy'}
+        responses.add(responses.POST, self.query_url, json=resp)
+
+        self.device.device_keys.clear()
+        assert download_device_keys(user_devices)
+        req = json.loads(responses.calls[0].request.body)
+        assert req['device_keys'] == {self.alice: [], bob: [], self.user_id: []}
+        expected_device_keys = {
+            self.alice: {
+                'JLAFKJWSCS': {
+                    'curve25519': '3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI',
+                    'ed25519': 'VzJIYXQ85u19z2ZpEeLLVu8hUKTCE0VXYUn4IY4iFcA'
+                }
+            }
+        }
+        assert self.device.device_keys == expected_device_keys
+
+        # Different curve25519, key should get updated
+        assert download_device_keys(user_devices)
+        expected_device_keys[self.alice]['JLAFKJWSCS']['curve25519'] = new_id_key
+        assert self.device.device_keys == expected_device_keys
+
+        # Different ed25519, key should not get updated
+        assert not download_device_keys(user_devices)
+        assert self.device.device_keys == expected_device_keys
+
+        self.device.device_keys.clear()
+        # All the remaining responses are wrong and we should not add the key
+        for _ in range(4):
+            assert not download_device_keys(user_devices)
+            assert self.device.device_keys == {}
+
+        assert len(responses.calls) == 7
+
+    @responses.activate
+    def test_update_thread(self):
+        # Normal run
+        event = Event()
+        outdated_users = OutdatedUsersSet({self.user_id})
+        outdated_users.events.add(event)
+
+        def dummy_download(user_devices, since_token=None):
+            assert user_devices == {self.user_id: []}
+            return
+        thread = UpdateDeviceList(Condition(), outdated_users, dummy_download, set())
+
+        thread.start()
+        event.wait()
+        assert not thread.outdated_user_ids
+        assert thread.event.is_set()
+        assert thread.tracked_user_ids == {self.user_id}
+        thread.join()
+        assert not thread.is_alive()
+
+        # Error run
+        outdated_users = OutdatedUsersSet({self.user_id})
+
+        def error_on_first_download(user_devices, since_token=None):
+            error_on_first_download.c += 1
+            if error_on_first_download.c == 1:
+                raise MatrixRequestError
+            return
+        error_on_first_download.c = 0
+        thread = UpdateDeviceList(
+            Condition(), outdated_users, error_on_first_download, set())
+        thread.start()
+        thread.event.wait()
+        assert error_on_first_download.c == 2
+        assert not thread.outdated_user_ids
+        thread.join()
+
+        # Cover a missing branch
+        thread = UpdateDeviceList(
+            Condition(), outdated_users, error_on_first_download, set())
+        thread._should_terminate.set()
+        thread.start()
+        thread.join()
+        assert not thread.is_alive()
+
+    @responses.activate
+    def test_get_room_device_keys(self):
+        self.device_list.tracked_user_ids.clear()
+        room = self.cli._mkroom(self.room_id)
+        room._members[self.alice] = User(self.cli.api, self.alice)
+
+        responses.add(responses.POST, self.query_url, json=example_key_query_response)
+
+        # Blocking
+        self.device_list.get_room_device_keys(room)
+        assert self.device_list.tracked_user_ids == {self.alice}
+        assert self.device_list.device_keys[self.alice]['JLAFKJWSCS']
+
+        # Same, but we already track the user
+        self.device_list.get_room_device_keys(room)
+
+        # Non-blocking
+        self.device_list.tracked_user_ids.clear()
+        # We have to block for testing purposes, though
+        self.device_list.update_thread.event.clear()
+        self.device_list.get_room_device_keys(room, blocking=False)
+        self.device_list.update_thread.event.wait()
+
+        # Same, but we already track the user
+        self.device_list.get_room_device_keys(room, blocking=False)
+
+    @responses.activate
+    def test_add_users(self):
+        self.device_list.tracked_user_ids.clear()
+        responses.add(responses.POST, self.query_url, json=example_key_query_response)
+
+        self.device_list.update_thread.event.clear()
+        self.device_list.add_users({self.alice})
+        self.device_list.update_thread.event.wait()
+        assert self.device_list.tracked_user_ids == {self.alice}
+        assert len(responses.calls) == 1
+
+        # Same, but we are already tracking Alice
+        self.device_list.add_users({self.alice})
+        assert len(responses.calls) == 1
+
+    def test_stop_tracking_users(self):
+        self.device_list.tracked_user_ids.clear()
+        self.device_list.tracked_user_ids.add(self.alice)
+        self.device_list.outdated_user_ids.clear()
+        self.device_list.outdated_user_ids.add(self.alice)
+
+        self.device_list.stop_tracking_users({self.alice})
+
+        assert not self.device_list.tracked_user_ids
+        assert not self.device_list.outdated_user_ids
+
+    @responses.activate
+    def test_update_user_device_keys(self):
+        self.device_list.tracked_user_ids.clear()
+        responses.add(responses.POST, self.query_url, json=example_key_query_response)
+
+        self.device_list.update_user_device_keys({self.alice})
+        assert len(responses.calls) == 0
+
+        self.device_list.tracked_user_ids.add(self.alice)
+
+        self.device_list.update_thread.event.clear()
+        self.device_list.update_user_device_keys({self.alice}, since_token='dummy')
+        self.device_list.update_thread.event.wait()
+        assert len(responses.calls) == 1
+
+
+def test_outdated_users_set():
+    s = OutdatedUsersSet()
+    assert not s
+
+    s = OutdatedUsersSet({1})
+    event = Event()
+    s.events.add(event)
+    assert s == {1}
+
+    # Make a manual copy of s
+    t = OutdatedUsersSet()
+    t.add(1)
+    t.events.add(event)
+    assert t == s and t.events == s.events
+
+    u = s.copy()
+    event2 = Event()
+    u.add(2)
+    u.events.add(event2)
+    # Check that modifying u didn't change s
+    assert t == s and t.events == s.events
+
+    s.update(u)
+    assert s == {1, 2} and s.events == {event, event2}
+
+    s.mark_as_processed()
+    assert event.is_set()
+
+    new = 's72594_4483_1935'
+    s.sync_token = new
+    old = 's72594_4483_1934'
+    s.sync_token = old
+    assert s.sync_token == new
+
+    s.clear()
+    assert not s and not s.events

--- a/test/crypto/device_list_test.py
+++ b/test/crypto/device_list_test.py
@@ -11,9 +11,9 @@ from matrix_client.api import MATRIX_V2_API_PATH
 from matrix_client.client import MatrixClient
 from matrix_client.room import User
 from matrix_client.errors import MatrixRequestError
-from matrix_client.crypto.olm_device import OlmDevice
 from matrix_client.crypto.device_list import (_OutdatedUsersSet as OutdatedUsersSet,
                                               _UpdateDeviceList as UpdateDeviceList)
+from test.crypto.dummy_olm_device import OlmDevice
 from test.response_examples import example_key_query_response
 
 HOSTNAME = 'http://example.com'

--- a/test/crypto/dummy_olm_device.py
+++ b/test/crypto/dummy_olm_device.py
@@ -1,0 +1,21 @@
+"""Tests can import OlmDevice from here, and know it won't try to use a database."""
+
+from matrix_client.crypto.crypto_store import CryptoStore
+from matrix_client.crypto.olm_device import OlmDevice as BaseOlmDevice
+
+
+class DummyStore(CryptoStore):
+    def __init__(*args, **kw): pass
+
+    def nop(*args, **kw): pass
+
+    def __getattribute__(self, name):
+        if name in dir(CryptoStore):
+            return object.__getattribute__(self, 'nop')
+        raise AttributeError
+
+
+class OlmDevice(BaseOlmDevice):
+
+    def __init__(self, *args, **kw):
+        super(OlmDevice, self).__init__(*args, Store=DummyStore, **kw)

--- a/test/crypto/olm_device_test.py
+++ b/test/crypto/olm_device_test.py
@@ -17,6 +17,7 @@ HOSTNAME = 'http://example.com'
 class TestOlmDevice:
     cli = MatrixClient(HOSTNAME)
     user_id = '@user:matrix.org'
+    room_id = '!test:example.com'
     device_id = 'QBUAZIFURK'
     device = OlmDevice(cli.api, user_id, device_id)
     signing_key = device.olm_account.identity_keys['ed25519']

--- a/test/crypto/olm_device_test.py
+++ b/test/crypto/olm_device_test.py
@@ -16,7 +16,7 @@ from matrix_client.crypto import olm_device
 from matrix_client.api import MATRIX_V2_API_PATH
 from matrix_client.client import MatrixClient
 from matrix_client.user import User
-from matrix_client.crypto.olm_device import OlmDevice
+from test.crypto.dummy_olm_device import OlmDevice
 from matrix_client.crypto.megolm_outbound_session import MegolmOutboundSession
 from test.response_examples import (example_key_upload_response,
                                     example_claim_keys_response,

--- a/test/response_examples.py
+++ b/test/response_examples.py
@@ -184,3 +184,34 @@ example_preview_url = {
     "og:image:width": 48,
     "og:title": "Matrix Blog Post"
 }
+
+example_key_query_response = {
+    "failures": {},
+    "device_keys": {
+        "@alice:example.com": {
+            "JLAFKJWSCS": {
+                "user_id": "@alice:example.com",
+                "device_id": "JLAFKJWSCS",
+                "algorithms": [
+                    "m.olm.curve25519-aes-sha256",
+                    "m.megolm.v1.aes-sha"
+                ],
+                "keys": {
+                    "curve25519:JLAFKJWSCS": ("3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIAr"
+                                              "zgyI"),
+                    "ed25519:JLAFKJWSCS": "VzJIYXQ85u19z2ZpEeLLVu8hUKTCE0VXYUn4IY4iFcA"
+                },
+                "signatures": {
+                    "@alice:example.com": {
+                        "ed25519:JLAFKJWSCS":
+                        ("wux6Dhjtk7GYPMW54hnx0doVH0NvuUAFBleL5OW99jhbjIutufglAgrYAcu8"
+                         "ueacgNyeSumvtzVIPZXgbB2BCg")
+                    }
+                },
+                "unsigned": {
+                    "device_display_name": "Alice'smobilephone"
+                }
+            }
+        }
+    }
+}

--- a/test/response_examples.py
+++ b/test/response_examples.py
@@ -215,3 +215,24 @@ example_key_query_response = {
         }
     }
 }
+
+example_claim_keys_response = {
+    "failures": {},
+    "one_time_keys": {
+        "@alice:example.com": {
+            "JLAFKJWSCS": {
+                'signed_curve25519:AAAAAQ': {
+                    'key': '9UOzQjF2j2Xf8mBIiMgruuCkuWtD0ea9kvx63mO92Ws',
+                    'signatures': {
+                        '@alice:example.com': {
+                            'ed25519:JLAFKJWSCS': (
+                                '6O+VYxN7mVcr/j66YdHASRrpW4ydC/0FcYmEWVAGIFzU4+yjzxxinhQD'
+                                'l7InhhdGuXeQlk4/w/CyU76TY6wdBA'
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/response_examples.py
+++ b/test/response_examples.py
@@ -236,3 +236,20 @@ example_claim_keys_response = {
         }
     }
 }
+
+example_room_key_event = {
+    "sender": "@alice:example.com",
+    "sender_device": "JLAFKJWSCS",
+    "content": {
+        "algorithm": "m.megolm.v1.aes-sha2",
+        "room_id": "!test:example.com",
+        "session_id": "AVCXMm6LZ+J/vyCcomXmE48mbD1IyKbUBUd3UOW0wHE",
+        "session_key": (
+            "AgAAAAAJS98WXiCc90wJ23H1ucZ+XFCv8pN8C5p/XojdA6l7PWlFwAV1fQXe7afrQMRL9BxeeF8M"
+            "uNnpvGX0hGOWcW0e2LU3EzQ0j8+jhxrPkQHUOJ8387CjRSA9UTBDmw3y8xquy3cXvuGE5DSpFUU7"
+            "J7Xh+Dli8XRaRDCbmPmMtSdPMwFQlzJui2fif78gnKJl5hOPJmw9SMim1AVHd1DltMBx4vB/3Kse"
+            "G413GWJkw9T+G6y51bsNEKsSU23lnJz32u5XwgNY9qdFKxGA6WL1wZZS6/iGW4gfTU/Jk89aGSA8"
+            "Aw")
+    },
+    "type": "m.room_key"
+}


### PR DESCRIPTION
This is the last (big) part of the basics of E2E.

The persistence strategy is implemented using sqlite3, but it should be quite easy to override if needed.

Persisted data is loaded dynamically during runtime, but can optionally be fully loaded on launch.

On top of needing data to be loaded and saved at the right moment, the trickiest part is to guard from inconsistency when the client is shutdown. For example, saving a user as tracked before saving its devices keys info would result in the keys never being fetched in case the client shutdowns between the two.

Signed-off-by: Valentin Deniaud \<valentin.deniaud@inpt.fr\>