### PR TITLE
Query user_id from server when token provided

### DIFF
--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -993,3 +993,13 @@ class MatrixHttpApi(object):
         txn_id = str(self.txn_id) + str(int(time() * 1000))
         self.txn_id += 1
         return txn_id
+
+    def whoami(self):
+        """Determine user_id for authentificated user.
+        """
+        if not self.token:
+            raise MatrixError("Authentification required.")
+        return self._send(
+            "GET",
+            "/account/whoami"
+        )

--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from .api import MatrixHttpApi
-from .checks import check_user_id
 from .errors import MatrixRequestError, MatrixUnexpectedResponse
 from .room import Room
 from .user import User
@@ -54,9 +53,7 @@ class MatrixClient(object):
             e.g. (ex: https://localhost:8008 )
         token (Optional[str]): If you have an access token
             supply it here.
-        user_id (Optional[str]): You must supply the user_id
-            (as obtained when initially logging in to obtain
-            the token) if supplying a token; otherwise, ignored.
+        user_id (Optional[str]): Optional. Obsolete. For backward compatibility.
         valid_cert_check (bool): Check the homeservers
             certificate on connections?
         cache_level (CACHE): One of CACHE.NONE, CACHE.SOME, or
@@ -108,8 +105,12 @@ class MatrixClient(object):
     def __init__(self, base_url, token=None, user_id=None,
                  valid_cert_check=True, sync_filter_limit=20,
                  cache_level=CACHE.ALL, encryption=False, encryption_conf=None):
-        if token is not None and user_id is None:
-            raise ValueError("must supply user_id along with token")
+        if user_id:
+            warn(
+                "user_id is deprecated. "
+                "Now it is requested from the server.", DeprecationWarning
+            )
+
         if encryption and not ENCRYPTION_SUPPORT:
             raise ValueError("Failed to enable encryption. Please make sure the olm "
                              "library is available.")
@@ -145,8 +146,8 @@ class MatrixClient(object):
             # room_id: Room
         }
         if token:
-            check_user_id(user_id)
-            self.user_id = user_id
+            response = self.api.whoami()
+            self.user_id = response["user_id"]
             self._sync()
 
     def get_sync_token(self):

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -405,3 +405,36 @@ class TestRoomApi:
         assert req.method == 'POST'
         j = json.loads(req.body)
         assert not j["creation_content"]["m.federate"]
+
+
+class TestWhoamiQuery:
+    user_id = "@alice:example.com"
+    token = "Dp0YKRXwx0iWDhFj7lg3DVjwsWzGcUIgARljgyAip2JD8qd5dSaW" \
+            "cxowTKEFetPulfLijAhv8eOmUSScyGcWgZyNMRTBmoJ0RFc0HotPvTBZ" \
+            "U98yKRLtat7V43aCpFmK"
+
+    @responses.activate
+    def test_whoami(self):
+        mapi = api.MatrixHttpApi("http://example.com", token=self.token)
+        whoami_url = "http://example.com/_matrix/client/r0/account/whoami"
+        responses.add(
+            responses.GET,
+            whoami_url,
+            body='{"user_id": "%s"}' % self.user_id
+        )
+        mapi.whoami()
+        req = responses.calls[0].request
+        assert req.method == 'GET'
+        assert whoami_url in req.url
+
+    @responses.activate
+    def test_whoami_unauth(self):
+        mapi = api.MatrixHttpApi("http://example.com")
+        whoami_url = "http://example.com/_matrix/client/r0/account/whoami"
+        responses.add(
+            responses.GET,
+            whoami_url,
+            body='{"user_id": "%s"}' % self.user_id
+        )
+        with pytest.raises(MatrixError):
+            mapi.whoami()

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -17,6 +17,28 @@ def test_create_client():
     MatrixClient("http://example.com")
 
 
+@responses.activate
+def test_create_client_with_token():
+    user_id = "@alice:example.com"
+    token = "Dp0YKRXwx0iWDhFj7lg3DVjwsWzGcUIgARljgyAip2JD8qd5dSaW" \
+            "cxowTKEFetPulfLijAhv8eOmUSScyGcWgZyNMRTBmoJ0RFc0HotPvTBZ" \
+            "U98yKRLtat7V43aCpFmK"
+    whoami_url = HOSTNAME+MATRIX_V2_API_PATH+"/account/whoami"
+    responses.add(
+        responses.GET,
+        whoami_url,
+        body='{"user_id": "%s"}' % user_id
+    )
+    sync_response = deepcopy(response_examples.example_sync)
+    response_body = json.dumps(sync_response)
+    sync_url = HOSTNAME + MATRIX_V2_API_PATH + "/sync"
+    responses.add(responses.GET, sync_url, body=response_body)
+    MatrixClient(HOSTNAME, token=token)
+    req = responses.calls[0].request
+    assert req.method == 'GET'
+    assert whoami_url in req.url
+
+
 def test_sync_token():
     client = MatrixClient("http://example.com")
     assert client.get_sync_token() is None


### PR DESCRIPTION
Trying to fix issue https://github.com/matrix-org/matrix-python-sdk/issues/38 

- implemented `whoami` API method https://matrix.org/docs/spec/client_server/r0.3.0.html#get-matrix-client-r0-account-whoami
- implemented tests for `whoami` API method
- added `user_id` detection with `whoami` API method if `token` at client initialization provided
- added deprication warning if `user_id` at client initialization provided
- implemented test forclient initialization with token provided

Signed-off-by: Pavel Kardash <slipeer@gmail.com>