### PR TITLE
Revert "Explicitly declare sudo for Travis"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: required
+sudo: false
 language: python
 python:
   - "2.7"


### PR DESCRIPTION
This reverts commit f0b1603663f1e61085f27cbdd4c24fdfec88d728.
It was a workaround a temporary Travis issue. See https://github.com/travis-ci/travis-ci/issues/9875#issuecomment-408867228.

Signed-off-by: Valentin Deniaud <valentin.deniaud@inpt.fr>