### PR TITLE
Do not add empty user displaynames in rooms

### DIFF
--- a/matrix_client/room.py
+++ b/matrix_client/room.py
@@ -486,7 +486,8 @@ class Room(object):
         return list(self._members.values())
 
     def _add_member(self, user_id, displayname=None):
-        self.members_displaynames[user_id] = displayname
+        if displayname:
+            self.members_displaynames[user_id] = displayname
         if user_id in self._members:
             return
         if user_id in self.client.users:


### PR DESCRIPTION
According to the logic in `User.get_display_name`, this is how it should have been. Also fixes an exception thrown in `Room.display_name` (when sorting).

Signed-off-by: Valentin Deniaud \<valentin.deniaud@inpt.fr\>