### PR TITLE
Add support for filename when uploading media

### DIFF
--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -744,12 +744,17 @@ class MatrixHttpApi(object):
 
         return response.json()
 
-    def media_upload(self, content, content_type):
+    def media_upload(self, content, content_type, filename=None):
+        query_params = {}
+        if filename is not None:
+            query_params['filename'] = filename
+
         return self._send(
             "POST", "",
             content=content,
             headers={"Content-Type": content_type},
-            api_path="/_matrix/media/r0/upload"
+            api_path="/_matrix/media/r0/upload",
+            query_params=query_params
         )
 
     def get_display_name(self, user_id):

--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -538,19 +538,20 @@ class MatrixClient(object):
             self.sync_thread = None
 
     # TODO: move to User class. Consider creating lightweight Media class.
-    def upload(self, content, content_type):
+    def upload(self, content, content_type, filename=None):
         """ Upload content to the home server and recieve a MXC url.
 
         Args:
             content (bytes): The data of the content.
             content_type (str): The mimetype of the content.
+            filename (str): Optional. Filename of the content.
 
         Raises:
             MatrixUnexpectedResponse: If the homeserver gave a strange response
             MatrixRequestError: If the upload failed for some reason.
         """
         try:
-            response = self.api.media_upload(content, content_type)
+            response = self.api.media_upload(content, content_type, filename)
             if "content_uri" in response:
                 return response["content_uri"]
             else:


### PR DESCRIPTION
There is a problem with filename when uploading files

When you trying to save file through Riot app it saving it like this (without correct filename):
![image](https://user-images.githubusercontent.com/1043901/44511380-fd186980-a6bf-11e8-9b22-1be2d9ade4df.png)

PR fix this issue by passing filename when uploading file
