### PR TITLE
Fix spelling in whoami exception

### DIFF
--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -995,10 +995,10 @@ class MatrixHttpApi(object):
         return txn_id
 
     def whoami(self):
-        """Determine user_id for authentificated user.
+        """Determine user_id for authenticated user.
         """
         if not self.token:
-            raise MatrixError("Authentification required.")
+            raise MatrixError("Authentication required.")
         return self._send(
             "GET",
             "/account/whoami"


### PR DESCRIPTION
https://en.wiktionary.org/wiki/authentification "Misspelling of authentication"