### PR TITLE
update Olm dependency version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ jobs:
       python: "3.7"
 
 before_install:
-  - wget https://matrix.org/git/olm/snapshot/olm-2.2.2.tar.bz2
-  - tar -xvf olm-2.2.2.tar.bz2
-  - pushd olm-2.2.2 && make && sudo make PREFIX="/usr" install && popd
-  - rm -r olm-2.2.2
+  - wget https://matrix.org/git/olm/snapshot/olm-2.3.0.tar.bz2
+  - tar -xvf olm-2.3.0.tar.bz2
+  - pushd olm-2.3.0 && make && sudo make PREFIX="/usr" install && popd
+  - rm -r olm-2.3.0
 install: pip install tox-travis
 script: tox

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,6 @@ setup(
         'e2e': ['python-olm==dev', 'canonicaljson']
     },
     dependency_links=[
-        'git+https://github.com/poljar/python-olm.git#egg=python-olm-dev'
+        'git+https://github.com/poljar/python-olm.git@4752eb22f005cb9f6143857008572e6d83252841#egg=python-olm-dev'
     ]
 )


### PR DESCRIPTION
Also depend on a specific commit of the Olm bindings so that master
doesn't suddenly break when they get updated.
This is still a workaround while we wait for them to be available on pip
or equivalent.