### PR TITLE
Fix missing update of start_token while backfill prev messages

### DIFF
--- a/matrix_client/room.py
+++ b/matrix_client/room.py
@@ -507,6 +507,7 @@ class Room(object):
         res = self.client.api.get_room_messages(self.room_id, self.prev_batch,
                                                 direction="b", limit=limit)
         events = res["chunk"]
+        self.prev_batch = res["end"]
         if not reverse:
             events = reversed(events)
         for event in events:


### PR DESCRIPTION
Hello,

while writing a script that should parse the whole channel history i wondered why i always got the same messages when i called backfill_previous_messages(). Please see the example code which i run with a room that just contains 30 messages (message 1 ... message 30).  

``` python
>>> from matrix_client.client import MatrixClient
>>> client = MatrixClient("https://synapse-server")
>>> token = client.login_with_password(username="mattthias", password="guesswhat")
>>> room = client.join_room("#matrixtest:synapse-server")
>>> print(room.events)
[]
>>> room.backfill_previous_messages()
>>> for event in room.events:
...   print(event['content'])
... 
{'body': 'Message 21', 'msgtype': 'm.text'}
{'body': 'Message 22', 'msgtype': 'm.text'}
{'body': 'Message 25', 'msgtype': 'm.text'}
{'body': 'Message 26', 'msgtype': 'm.text'}
{'body': 'Message 23', 'msgtype': 'm.text'}
{'body': 'Message 27', 'msgtype': 'm.text'}
{'body': 'Message 24', 'msgtype': 'm.text'}
{'body': 'Message 28', 'msgtype': 'm.text'}
{'body': 'Message 29', 'msgtype': 'm.text'}
{'body': 'Message 30', 'msgtype': 'm.text'}
>>> room.backfill_previous_messages()
>>> len(room.events)
20
>>> for event in room.events:
...     print(event['content'])
... 
{'body': 'Message 21', 'msgtype': 'm.text'}
{'body': 'Message 22', 'msgtype': 'm.text'}
{'body': 'Message 25', 'msgtype': 'm.text'}
{'body': 'Message 26', 'msgtype': 'm.text'}
{'body': 'Message 23', 'msgtype': 'm.text'}
{'body': 'Message 27', 'msgtype': 'm.text'}
{'body': 'Message 24', 'msgtype': 'm.text'}
{'body': 'Message 28', 'msgtype': 'm.text'}
{'body': 'Message 29', 'msgtype': 'm.text'}
{'body': 'Message 30', 'msgtype': 'm.text'}
{'body': 'Message 21', 'msgtype': 'm.text'}
{'body': 'Message 22', 'msgtype': 'm.text'}
{'body': 'Message 25', 'msgtype': 'm.text'}
{'body': 'Message 26', 'msgtype': 'm.text'}
{'body': 'Message 23', 'msgtype': 'm.text'}
{'body': 'Message 27', 'msgtype': 'm.text'}
{'body': 'Message 24', 'msgtype': 'm.text'}
{'body': 'Message 28', 'msgtype': 'm.text'}
{'body': 'Message 29', 'msgtype': 'm.text'}
{'body': 'Message 30', 'msgtype': 'm.text'}
>>> 

```

The function backfill_previous_messages() updates the room's event list
(room.events) using the api function "client.api.get_room_messages". The
latter function takes a start token as parameter to know from where in
the history of events to start.

backfill_previous_messages() handes over self.prev_batch as start token
but never updates it. So repeated calls to backfill_previous_messages()
always return the same chunk of events from the room's event history.

This commit fixes this wrong behavior by updating self.prev_batch on
every function call.

Signed-off-by: Matthias Schmitz <matthias@sigxcpu.org>