### PR TITLE
catch and log state event parse errors in _process_state_event

### DIFF
--- a/matrix_client/room.py
+++ b/matrix_client/room.py
@@ -671,9 +671,8 @@ class Room(object):
                     elif econtent["membership"] in ("leave", "kick", "invite"):
                         self._members.pop(state_event["state_key"], None)
             except KeyError:
-                id = state_event['event_id']
-                logger.error("Unable to parse state event %s, passing over." % id)
-                traceback.print_exc()
+                logger.exception("Unable to parse state event %s, passing over.",
+                                 state_event['event_id'])
 
         for listener in self.state_listeners:
             if (

--- a/matrix_client/room.py
+++ b/matrix_client/room.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 import logging
 import re
-
 from uuid import uuid4
 
 from .checks import check_room_id

--- a/matrix_client/room.py
+++ b/matrix_client/room.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 import logging
 import re
-import traceback
+
 from uuid import uuid4
 
 from .checks import check_room_id

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -99,7 +99,8 @@ def test_state_event():
 
     ev = {
         "type": "m.room.name",
-        "content": {}
+        "content": {},
+        "event_id": "$10000000000000AAAAA:matrix.org"
     }
 
     room._process_state_event(ev)
@@ -151,6 +152,13 @@ def test_state_event():
     ev["content"] = {"guest_access": "can_join"}
     room._process_state_event(ev)
     assert room.guest_access
+
+    # test malformed event (check does not throw exception)
+    room.guest_access = False
+    ev["type"] = "m.room.guest_access"
+    ev["content"] = {}
+    room._process_state_event(ev)
+    assert not room.guest_access
 
     # test encryption
     room.encrypted = False


### PR DESCRIPTION
I was recently playing around with the sdk and was unable to instantiate a client due to a malformed state event present in one of the rooms I am a member.

The event was of type ```m.room.guest_access``` and contrary to spec had a zero length ```content``` field.

I'm unclear how this event was ever created, however it means that I (and presumably others), cannot create clients for any account that that participates in such a room.

This PR logs out the error, but ignores it and carries on. 
