### PR TITLE
Make account_data accessible

### DIFF
--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -155,6 +155,9 @@ class MatrixClient(object):
         self.users = {
             # user_id: User
         }
+        self.account_data = {
+            # type: contents
+        }
         if token:
             response = self.api.whoami()
             self.user_id = response["user_id"]
@@ -638,6 +641,16 @@ class MatrixClient(object):
                     ):
                         listener['callback'](event)
 
+        for event in response['account_data']['events']:
+            self.account_data[event['type']] = event['content']
+
+            for listener in self.listeners:
+                if (
+                    listener['event_type'] is None or
+                    listener['event_type'] == event['type']
+                ):
+                    listener['callback'](event)
+
     def get_user(self, user_id):
         """Deprecated. Return a User by their id.
 
@@ -667,3 +680,14 @@ class MatrixClient(object):
             return True
         except MatrixRequestError:
             return False
+
+    def get_account_data(self):
+        """Return `account_data` structure
+
+        Returns:
+            dict: Formatted for use in e.g. `api.set_account_data`
+        """
+        events = []
+        for k,v in self.account_data.items():
+            events.append({'type': k, 'content': v})
+        return {'events': events}

--- a/samples/ListDirectChats.py
+++ b/samples/ListDirectChats.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+# Dump the list of direct chats
+# Args: host:port username password
+# Error Codes:
+# 2 - Could not find the server.
+# 3 - Bad URL Format.
+# 4 - Bad username/password.
+
+import sys
+import samples_common
+
+from matrix_client.client import MatrixClient
+from matrix_client.api import MatrixRequestError
+from requests.exceptions import MissingSchema
+
+
+host, username, password = samples_common.get_user_details(sys.argv)
+
+client = MatrixClient(host)
+
+try:
+    client.login_with_password_no_sync(username, password)
+except MatrixRequestError as e:
+    print(e)
+    if e.code == 403:
+        print("Bad username or password.")
+        sys.exit(4)
+    else:
+        print("Check your server details are correct.")
+        sys.exit(2)
+except MissingSchema as e:
+    print("Bad URL format.")
+    print(e)
+    sys.exit(3)
+
+room_ids = []
+
+import yaml
+print(yaml.dumps(client.account_data['m.direct']), default_flow_style=False)

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -78,6 +78,16 @@ def test_get_rooms():
     assert len(rooms) == 3
 
 
+def test_get_account_data():
+    client = MatrixClient("http://example.com")
+    assert isinstance(client.account_data, dict)
+    assert (len(client.account_data) == 0)
+
+    ab = client.get_account_data()
+    assert('events' in ab)
+    assert (len(ab['events']) == 0)
+
+
 def test_bad_state_events():
     client = MatrixClient("http://example.com")
     room = client._mkroom("!abc:matrix.org")


### PR DESCRIPTION
This keeps a copy of account_data in the Client object after a sync,
which can then be easily accessed through a dictionary.

In addition, Client.get_account_data is provided as a means to obtain
the current account_data structure for direct feeding into
Api.set_account_data.

Closes: #294
Signed-off-by: martin f. krafft <madduck@madduck.net>