### PR TITLE
Remove --process-dependency-links section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,14 +52,6 @@ needed dependencies.
    cd matrix-python-sdk
    python setup.py install
 
-E2E development
-~~~~~~~~~~~~~~~
-
-The Olm bindings are not yet hosted on PyPI. Hence it it necessary to pass
-``--process-dependency-links`` when installing with pip, in order to fetch them
-from their Git repository. For example replace ``python setup.py install`` in
-the above instructions by ``pip install --process-dependency-links .[e2e]``.
-
 Usage
 =====
 The SDK provides 2 layers of interaction. The low-level layer just wraps the


### PR DESCRIPTION
This option has been removed from pip and it is no longer required by matrix-python-sdk after https://github.com/matrix-org/matrix-python-sdk/commit/b3346dbfce5079a6977c4c3aedc438f21114f8c9