### PR TITLE
added api connection_timeout to recover from lost connections

### DIFF
--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -57,7 +57,8 @@ class MatrixHttpApi(object):
     def __init__(
             self, base_url, token=None, identity=None,
             default_429_wait_ms=5000,
-            use_authorization_header=True
+            use_authorization_header=True,
+            connection_timeout=60
     ):
         try:
             scheme, auth, host, port, path, query, fragment = parse_url(base_url)
@@ -74,6 +75,7 @@ class MatrixHttpApi(object):
         self.session = Session()
         self.default_429_wait_ms = default_429_wait_ms
         self.use_authorization_header = use_authorization_header
+        self.connection_timeout = connection_timeout
 
     def initial_sync(self, limit=1):
         """
@@ -725,7 +727,8 @@ class MatrixHttpApi(object):
                     params=query_params,
                     data=content,
                     headers=headers,
-                    verify=self.validate_cert
+                    verify=self.validate_cert,
+                    timeout=self.connection_timeout,
                 )
             except RequestException as e:
                 raise MatrixHttpLibError(e, method, endpoint)

--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -111,7 +111,8 @@ class MatrixClient(object):
 
     def __init__(self, base_url, token=None, user_id=None,
                  valid_cert_check=True, sync_filter_limit=20,
-                 cache_level=CACHE.ALL, encryption=False, encryption_conf=None):
+                 cache_level=CACHE.ALL, encryption=False, encryption_conf=None,
+                 api_connection_timeout=60):
         if user_id:
             warn(
                 "user_id is deprecated. "
@@ -122,7 +123,8 @@ class MatrixClient(object):
             raise ValueError("Failed to enable encryption. Please make sure the olm "
                              "library is available.")
 
-        self.api = MatrixHttpApi(base_url, token)
+        self.api = MatrixHttpApi(base_url, token,
+                                 connection_timeout=api_connection_timeout)
         self.api.validate_certificate(valid_cert_check)
         self.listeners = []
         self.presence_listeners = {}


### PR DESCRIPTION
if connection lost during listening the _send method does not return cause it calls self.session.request without the timeout keyword argument which defaults to None. i added an optional keyword argument to MatrixHttpApi and MatrixClient that specifies a timeout to pass to self.session.request
