### PR TITLE
Tox should use py35 for 3.5

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -37,5 +37,5 @@ commands = sphinx-build -W source build/html
 python =
     2.7: py27
     3.4: py34
-    3.5: py34
+    3.5: py35
     3.6: py36, pep8, docs


### PR DESCRIPTION
This will depend on #307 being merged first.