### PR TITLE
Replace deprecated calls

### DIFF
--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -341,7 +341,7 @@ class MatrixClient(object):
         return self._mkroom(room_id)
 
     def get_rooms(self):
-        """ Return a dict of {room_id: Room objects} that the user has joined.
+        """ Deprecated. Return a dict of {room_id: Room objects} that the user has joined.
 
         Returns:
             Room{}: Rooms the user has joined.

--- a/samples/ChangeDisplayName.py
+++ b/samples/ChangeDisplayName.py
@@ -13,6 +13,7 @@ import samples_common
 
 from matrix_client.client import MatrixClient
 from matrix_client.api import MatrixRequestError
+from matrix_client.user import User
 from requests.exceptions import MissingSchema
 
 
@@ -35,7 +36,7 @@ except MissingSchema as e:
     print(e)
     sys.exit(3)
 
-user = client.get_user(client.user_id)
+user = User(client.api, client.user_id)
 
 if len(sys.argv) < 5:
     print("Current Display Name: %s" % user.get_display_name())

--- a/samples/UserPassOrTokenClient.py
+++ b/samples/UserPassOrTokenClient.py
@@ -27,7 +27,7 @@ def example(host, user, password, token):
     try:
         if token:
             print('token login')
-            client = MatrixClient(host, token=token, user_id=user)
+            client = MatrixClient(host, token=token)
         else:
             print('password login')
             client = MatrixClient(host)


### PR DESCRIPTION
The goal of this PR is to update the documentation of the library so it:
 - adds a 'Deprecated' info in docstring so the next documentation
 - removes some examples of deprecated uses in samples/ directory