### PR TITLE
Added the ability to provide credentials under the form of a custom

### DIFF
--- a/matrix_client/api.py
+++ b/matrix_client/api.py
@@ -180,6 +180,14 @@ class MatrixHttpApi(object):
 
         return self._send("POST", "/login", content)
 
+    def login(self, auth_string):
+        """Perform /login.
+
+        Args:
+            auth_string(str): The auth string to user for authenticating. The string is built elsewhere.
+        """
+        return self._send("POST", "/login", auth_string)
+
     def logout(self):
         """Perform /logout.
         """


### PR DESCRIPTION
(useful for third party authentication in some matrix deployments).
Hi, for some matrix instances (for example Thalès Citadel), it is necessary to use an auth string that is somewhat different.

This PR for letting users define their own auth-string.

Shall changes be needed, please do not hesitate to let me know.