### PR TITLE
handle smaller sync responses introduced in synapse 1.38.0

### DIFF
--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -613,12 +613,12 @@ class MatrixClient(object):
                     # TODO: the rest of this for loop should be in room object method
                     room.prev_batch = sync_room["timeline"]["prev_batch"]
 
-                    if "events" in sync_room["state"]:
+                    if "state" in sync_room and "events" in sync_room["state"]:
                         for event in sync_room["state"]["events"]:
                             event['room_id'] = room_id
                             room._process_state_event(event)
 
-                    if "events" in sync_room["timeline"]:
+                    if "timeline" in sync_room and "events" in sync_room["timeline"]:
                         for event in sync_room["timeline"]["events"]:
                             event['room_id'] = room_id
                             room._put_event(event)
@@ -634,7 +634,7 @@ class MatrixClient(object):
                                 ):
                                     listener['callback'](event)
 
-                    if "events" in sync_room["ephemeral"]:
+                    if "ephemeral" in sync_room and "events" in sync_room["ephemeral"]:
                         for event in sync_room['ephemeral']['events']:
                             event['room_id'] = room_id
                             room._put_ephemeral_event(event)

--- a/matrix_client/client.py
+++ b/matrix_client/client.py
@@ -583,60 +583,68 @@ class MatrixClient(object):
         response = self.api.sync(self.sync_token, timeout_ms, filter=self.sync_filter)
         self.sync_token = response["next_batch"]
 
-        for presence_update in response['presence']['events']:
-            for callback in self.presence_listeners.values():
-                callback(presence_update)
-
-        for room_id, invite_room in response['rooms']['invite'].items():
-            for listener in self.invite_listeners:
-                listener(room_id, invite_room['invite_state'])
-
-        for room_id, left_room in response['rooms']['leave'].items():
-            for listener in self.left_listeners:
-                listener(room_id, left_room)
-            if room_id in self.rooms:
-                del self.rooms[room_id]
+        if 'presence' in response and 'events' in response['presence']:
+            for presence_update in response['presence']['events']:
+                for callback in self.presence_listeners.values():
+                    callback(presence_update)
 
         if self._encryption and 'device_one_time_keys_count' in response:
             self.olm_device.update_one_time_key_counts(
                 response['device_one_time_keys_count'])
 
-        for room_id, sync_room in response['rooms']['join'].items():
-            if room_id not in self.rooms:
-                self._mkroom(room_id)
-            room = self.rooms[room_id]
-            # TODO: the rest of this for loop should be in room object method
-            room.prev_batch = sync_room["timeline"]["prev_batch"]
+        if 'rooms' in response:
+            if 'invite' in response['rooms']:
+                for room_id, invite_room in response['rooms']['invite'].items():
+                    for listener in self.invite_listeners:
+                        listener(room_id, invite_room['invite_state'])
 
-            for event in sync_room["state"]["events"]:
-                event['room_id'] = room_id
-                room._process_state_event(event)
+            if 'leave' in response['rooms']:
+                for room_id, left_room in response['rooms']['leave'].items():
+                    for listener in self.left_listeners:
+                        listener(room_id, left_room)
+                    if room_id in self.rooms:
+                        del self.rooms[room_id]
 
-            for event in sync_room["timeline"]["events"]:
-                event['room_id'] = room_id
-                room._put_event(event)
+            if 'join' in response['rooms']:
+                for room_id, sync_room in response['rooms']['join'].items():
+                    if room_id not in self.rooms:
+                        self._mkroom(room_id)
+                    room = self.rooms[room_id]
+                    # TODO: the rest of this for loop should be in room object method
+                    room.prev_batch = sync_room["timeline"]["prev_batch"]
 
-                # TODO: global listeners can still exist but work by each
-                # room.listeners[uuid] having reference to global listener
+                    if "events" in sync_room["state"]:
+                        for event in sync_room["state"]["events"]:
+                            event['room_id'] = room_id
+                            room._process_state_event(event)
 
-                # Dispatch for client (global) listeners
-                for listener in self.listeners:
-                    if (
-                        listener['event_type'] is None or
-                        listener['event_type'] == event['type']
-                    ):
-                        listener['callback'](event)
+                    if "events" in sync_room["timeline"]:
+                        for event in sync_room["timeline"]["events"]:
+                            event['room_id'] = room_id
+                            room._put_event(event)
 
-            for event in sync_room['ephemeral']['events']:
-                event['room_id'] = room_id
-                room._put_ephemeral_event(event)
+                            # TODO: global listeners can still exist but work by each
+                            # room.listeners[uuid] having reference to global listener
 
-                for listener in self.ephemeral_listeners:
-                    if (
-                        listener['event_type'] is None or
-                        listener['event_type'] == event['type']
-                    ):
-                        listener['callback'](event)
+                            # Dispatch for client (global) listeners
+                            for listener in self.listeners:
+                                if (
+                                    listener['event_type'] is None or
+                                    listener['event_type'] == event['type']
+                                ):
+                                    listener['callback'](event)
+
+                    if "events" in sync_room["ephemeral"]:
+                        for event in sync_room['ephemeral']['events']:
+                            event['room_id'] = room_id
+                            room._put_ephemeral_event(event)
+
+                            for listener in self.ephemeral_listeners:
+                                if (
+                                    listener['event_type'] is None or
+                                    listener['event_type'] == event['type']
+                                ):
+                                    listener['callback'](event)
 
     def get_user(self, user_id):
         """Deprecated. Return a User by their id.


### PR DESCRIPTION
Synapse 1.38.0 introduced smaller sync responses (https://github.com/matrix-org/synapse/pull/10214) by removing empty fields, but this library did not handle it correctly.
This broke the Home Assistant matrix integration, for example.
