### PR TITLE
Update setup.py, exclude test package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     author='The Matrix.org Team',
     author_email='team@matrix.org',
     url='https://github.com/matrix-org/matrix-python-sdk',
-    packages=find_packages(),
+    packages=find_packages(exclude=['test*']),
     license='Apache License, Version 2.0',
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
otherwise this one would try to install a package called 'test' at top level, which is very bad style (and also forbidden):

```
>>> Emerging (1 of 1) dev-python/matrix-client-0.4.0::HomeAssistantRepository
>>> Failed to emerge dev-python/matrix-client-0.4.0, Log file:
>>>  '/var/tmp/portage/dev-python/matrix-client-0.4.0/temp/build.log'
>>> Jobs: 0 of 1 complete, 1 failed                 Load avg: 0.32, 0.48, 0.52
 * Package:    dev-python/matrix-client-0.4.0
 * Repository: HomeAssistantRepository
 * Maintainer: b@edevau.net
 * Upstream:   team@matrix.org
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux python_targets_python3_9 test userland_GNU
 * FEATURES:   network-sandbox preserve-libs sandbox userpriv usersandbox
>>> Unpacking source...
>>> Unpacking matrix-client-0.4.0.tar.gz to /var/tmp/portage/dev-python/matrix-client-0.4.0/work
>>> Source unpacked in /var/tmp/portage/dev-python/matrix-client-0.4.0/work
>>> Preparing source in /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0 ...
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0 ...
locale: Cannot set LC_ALL to default locale: No such file or directory
>>> Source configured.
>>> Compiling source in /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0 ...
 * python3_9: running distutils-r1_run_phase distutils-r1_python_compile
python3.9 setup.py build -j 6
running build
running build_py
creating /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/test
copying test/client_test.py -> /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/test
copying test/response_examples.py -> /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/test
copying test/api_test.py -> /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/test
copying test/user_test.py -> /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/test
copying test/__init__.py -> /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/test
creating /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/matrix_client
copying matrix_client/checks.py -> /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/matrix_client
copying matrix_client/room.py -> /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/matrix_client
copying matrix_client/api.py -> /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/matrix_client
copying matrix_client/__init__.py -> /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/matrix_client
copying matrix_client/client.py -> /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/matrix_client
copying matrix_client/errors.py -> /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/matrix_client
copying matrix_client/user.py -> /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/matrix_client
creating /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/matrix_client/crypto
copying matrix_client/crypto/__init__.py -> /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/matrix_client/crypto
copying matrix_client/crypto/one_time_keys.py -> /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/matrix_client/crypto
copying matrix_client/crypto/olm_device.py -> /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/matrix_client/crypto
warning: build_py: byte-compiling is disabled, skipping.

>>> Source compiled.
>>> Test phase [not enabled]: dev-python/matrix-client-0.4.0

>>> Install dev-python/matrix-client-0.4.0 into /var/tmp/portage/dev-python/matrix-client-0.4.0/image
 * python3_9: running distutils-r1_run_phase distutils-r1_python_install
python3.9 setup.py install --skip-build --root=/var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9
running install
running install_lib
creating /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9
creating /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr
creating /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib
creating /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9
creating /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages
creating /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/test
copying /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/test/client_test.py -> /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/test
copying /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/test/response_examples.py -> /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/test
copying /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/test/api_test.py -> /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/test
copying /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/test/user_test.py -> /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/test
copying /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/test/__init__.py -> /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/test
creating /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/matrix_client
creating /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/matrix_client/crypto
copying /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/matrix_client/crypto/__init__.py -> /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/matrix_client/crypto
copying /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/matrix_client/crypto/one_time_keys.py -> /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/matrix_client/crypto
copying /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/matrix_client/crypto/olm_device.py -> /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/matrix_client/crypto
copying /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/matrix_client/checks.py -> /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/matrix_client
copying /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/matrix_client/room.py -> /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/matrix_client
copying /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/matrix_client/api.py -> /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/matrix_client
copying /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/matrix_client/__init__.py -> /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/matrix_client
copying /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/matrix_client/client.py -> /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/matrix_client
copying /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/matrix_client/errors.py -> /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/matrix_client
copying /var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0-python3_9/lib/matrix_client/user.py -> /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/matrix_client
byte-compiling /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/test/client_test.py to client_test.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/test/response_examples.py to response_examples.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/test/api_test.py to api_test.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/test/user_test.py to user_test.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/test/__init__.py to __init__.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/matrix_client/crypto/__init__.py to __init__.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/matrix_client/crypto/one_time_keys.py to one_time_keys.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/matrix_client/crypto/olm_device.py to olm_device.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/matrix_client/checks.py to checks.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/matrix_client/room.py to room.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/matrix_client/api.py to api.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/matrix_client/__init__.py to __init__.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/matrix_client/client.py to client.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/matrix_client/errors.py to errors.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/matrix_client/user.py to user.cpython-39.pyc
writing byte-compilation script '/var/tmp/portage/dev-python/matrix-client-0.4.0/temp/tmpto96xppb.py'
/usr/bin/python3.9 /var/tmp/portage/dev-python/matrix-client-0.4.0/temp/tmpto96xppb.py
removing /var/tmp/portage/dev-python/matrix-client-0.4.0/temp/tmpto96xppb.py
writing byte-compilation script '/var/tmp/portage/dev-python/matrix-client-0.4.0/temp/tmpzetlfzzt.py'
/usr/bin/python3.9 /var/tmp/portage/dev-python/matrix-client-0.4.0/temp/tmpzetlfzzt.py
removing /var/tmp/portage/dev-python/matrix-client-0.4.0/temp/tmpzetlfzzt.py
running install_egg_info
running egg_info
writing matrix_client.egg-info/PKG-INFO
writing dependency_links to matrix_client.egg-info/dependency_links.txt
writing requirements to matrix_client.egg-info/requires.txt
writing top-level names to matrix_client.egg-info/top_level.txt
reading manifest file 'matrix_client.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
adding license file 'LICENSE'
writing manifest file 'matrix_client.egg-info/SOURCES.txt'
Copying matrix_client.egg-info to /var/tmp/portage/dev-python/matrix-client-0.4.0/image/_python3.9/usr/lib/python3.9/site-packages/matrix_client-0.4.0-py3.9.egg-info
running install_scripts
 * ERROR: dev-python/matrix-client-0.4.0::HomeAssistantRepository failed (install phase):
 *   Package installs 'test' package which is forbidden and likely a bug in the build system.
 *
 * Call stack:
 *     ebuild.sh, line  127:  Called src_install
 *   environment, line 2847:  Called distutils-r1_src_install
 *   environment, line 1184:  Called _distutils-r1_run_foreach_impl 'distutils-r1_python_install'
 *   environment, line  455:  Called python_foreach_impl 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2522:  Called multibuild_foreach_variant '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2053:  Called _multibuild_run '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2051:  Called _python_multibuild_wrapper 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line  769:  Called distutils-r1_run_phase 'distutils-r1_python_install'
 *   environment, line 1152:  Called distutils-r1_python_install
 *   environment, line 1055:  Called die
 * The specific snippet of code:
 *               die "Package installs '${p}' package which is forbidden and likely a bug in the build system.";
 *
 * If you need support, post the output of `emerge --info '=dev-python/matrix-client-0.4.0::HomeAssistantRepository'`,
 * the complete build log and the output of `emerge -pqv '=dev-python/matrix-client-0.4.0::HomeAssistantRepository'`.
 * The complete build log is located at '/var/tmp/portage/dev-python/matrix-client-0.4.0/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/dev-python/matrix-client-0.4.0/temp/environment'.
 * Working directory: '/var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0'
 * S: '/var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0'

 * Messages for package dev-python/matrix-client-0.4.0:

 * ERROR: dev-python/matrix-client-0.4.0::HomeAssistantRepository failed (install phase):
 *   Package installs 'test' package which is forbidden and likely a bug in the build system.
 *
 * Call stack:
 *     ebuild.sh, line  127:  Called src_install
 *   environment, line 2847:  Called distutils-r1_src_install
 *   environment, line 1184:  Called _distutils-r1_run_foreach_impl 'distutils-r1_python_install'
 *   environment, line  455:  Called python_foreach_impl 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2522:  Called multibuild_foreach_variant '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2053:  Called _multibuild_run '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2051:  Called _python_multibuild_wrapper 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line  769:  Called distutils-r1_run_phase 'distutils-r1_python_install'
 *   environment, line 1152:  Called distutils-r1_python_install
 *   environment, line 1055:  Called die
 * The specific snippet of code:
 *               die "Package installs '${p}' package which is forbidden and likely a bug in the build system.";
 *
 * If you need support, post the output of `emerge --info '=dev-python/matrix-client-0.4.0::HomeAssistantRepository'`,
 * the complete build log and the output of `emerge -pqv '=dev-python/matrix-client-0.4.0::HomeAssistantRepository'`.
 * The complete build log is located at '/var/tmp/portage/dev-python/matrix-client-0.4.0/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/dev-python/matrix-client-0.4.0/temp/environment'.
 * Working directory: '/var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0'
 * S: '/var/tmp/portage/dev-python/matrix-client-0.4.0/work/matrix_client-0.4.0'
```